### PR TITLE
Enhance MCP tool accuracy and JSONRPC notification handling

### DIFF
--- a/pkg/ai/agent/conversation.go
+++ b/pkg/ai/agent/conversation.go
@@ -177,12 +177,17 @@ func (a *Agent) callLLM() error {
 	if toolProvider != nil && toolRegistry != nil {
 		// Use tool-enabled asking
 		toolDefs := a.buildToolDefinitions()
+		prompt := anonymizedPrompt
+		// When MCP tools exist: add strict name instruction. Skip for kubectl/bash only.
+		if len(toolRegistry.GetMCPTools()) > 0 {
+			prompt = tools.ToolNameInstruction + prompt
+		}
 
 		toolCallback := func(call providers.ToolCall) providers.ToolResult {
 			return a.handleToolCall(call)
 		}
 
-		err := toolProvider.AskWithTools(a.ctx, anonymizedPrompt, toolDefs, streamCallback, toolCallback)
+		err := toolProvider.AskWithTools(a.ctx, prompt, toolDefs, streamCallback, toolCallback)
 		if err != nil {
 			return err
 		}

--- a/pkg/ai/client.go
+++ b/pkg/ai/client.go
@@ -299,6 +299,12 @@ func (c *Client) AskWithToolsAndExecution(ctx context.Context, prompt string, ca
 		}
 	}
 
+	// When MCP tools are available: add strict name instruction (avoids pod_list vs pods_list etc.)
+	// and preference hint. Skip when only kubectl/bash - no extra tokens, no performance impact.
+	if len(c.toolRegistry.GetMCPTools()) > 0 {
+		prompt = tools.ToolNameInstruction + "When the user explicitly requests a specific tool, use that tool. When MCP tools are available and match the task, prefer them.\n\n" + prompt
+	}
+
 	return toolProvider.AskWithTools(ctx, prompt, toolDefs, callback, toolCallback)
 }
 

--- a/pkg/ai/tools/tools.go
+++ b/pkg/ai/tools/tools.go
@@ -11,6 +11,11 @@ import (
 	"time"
 )
 
+// ToolNameInstruction is prepended when MCP tools are present.
+// MCP tools (pods_list, namespaces_list, etc.) have specific names that LLMs may guess incorrectly.
+// Not used for kubectl/bash only - those names are standard and unlikely to be hallucinated.
+const ToolNameInstruction = "CRITICAL: Use ONLY the exact tool names from the function schema. Never invent, guess, or abbreviate tool names (e.g. do not use pod_list if the schema says pods_list).\n\n"
+
 // ToolType represents the type of tool
 type ToolType string
 
@@ -236,7 +241,7 @@ func (r *Registry) Execute(ctx context.Context, call *ToolCall) *ToolResult {
 	if !ok {
 		return &ToolResult{
 			ToolCallID: call.ID,
-			Content:    fmt.Sprintf("Unknown tool: %s", call.Function.Name),
+			Content:    fmt.Sprintf("Unknown tool: %s. Use only the exact tool names from the function schema. Retry with the correct name.", call.Function.Name),
 			IsError:    true,
 		}
 	}

--- a/pkg/mcp/client.go
+++ b/pkg/mcp/client.go
@@ -2,8 +2,10 @@ package mcp
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -14,25 +16,28 @@ import (
 	"time"
 
 	"github.com/cloudbro-kube-ai/k13d/pkg/config"
+	"github.com/cloudbro-kube-ai/k13d/pkg/log"
 )
 
 // Client manages MCP server connections
 type Client struct {
-	servers map[string]*ServerConnection
-	mu      sync.RWMutex
+	servers     map[string]*ServerConnection
+	mu          sync.RWMutex
+	OnReconnect func(serverName string) // called after successful reconnect; used to re-register tools
 }
 
 // ServerConnection represents a connection to an MCP server
 type ServerConnection struct {
-	config  config.MCPServer
-	cmd     *exec.Cmd
-	stdin   io.WriteCloser
-	stdout  io.ReadCloser
-	scanner *bufio.Scanner
-	reqID   atomic.Int64
-	mu      sync.Mutex
-	tools   []Tool
-	ready   bool
+	config    config.MCPServer
+	cmd       *exec.Cmd
+	stdin     io.WriteCloser
+	stdout    io.ReadCloser
+	scanner   *bufio.Scanner
+	stderrBuf *bytes.Buffer // captures MCP server stderr for debugging crashes
+	reqID     atomic.Int64
+	mu        sync.Mutex
+	tools     []Tool
+	ready     bool
 }
 
 // Tool represents an MCP tool definition
@@ -104,7 +109,7 @@ type ListToolsResult struct {
 // CallToolParams represents parameters for tools/call
 type CallToolParams struct {
 	Name      string                 `json:"name"`
-	Arguments map[string]interface{} `json:"arguments,omitempty"`
+	Arguments map[string]interface{} `json:"arguments"`
 }
 
 // CallToolResult represents the result of tools/call
@@ -182,6 +187,9 @@ func (c *Client) startServer(ctx context.Context, serverCfg config.MCPServer) (*
 		return nil, fmt.Errorf("failed to create stdout pipe: %w", err)
 	}
 
+	stderrBuf := &bytes.Buffer{}
+	cmd.Stderr = stderrBuf
+
 	if err := cmd.Start(); err != nil {
 		stdin.Close()
 		stdout.Close()
@@ -193,12 +201,13 @@ func (c *Client) startServer(ctx context.Context, serverCfg config.MCPServer) (*
 	scanner.Buffer(make([]byte, 0, 10*1024*1024), 10*1024*1024)
 
 	conn := &ServerConnection{
-		config:  serverCfg,
-		cmd:     cmd,
-		stdin:   stdin,
-		stdout:  stdout,
-		scanner: scanner,
-		tools:   make([]Tool, 0),
+		config:    serverCfg,
+		cmd:       cmd,
+		stdin:     stdin,
+		stdout:    stdout,
+		scanner:   scanner,
+		stderrBuf: stderrBuf,
+		tools:     make([]Tool, 0),
 	}
 
 	return conn, nil
@@ -242,12 +251,68 @@ func (c *Client) GetAllTools() []Tool {
 	return allTools
 }
 
+// isConnectionError returns true if the error indicates a broken connection (e.g. broken pipe)
+func isConnectionError(err error) bool {
+	if err == nil {
+		return false
+	}
+	s := err.Error()
+	return strings.Contains(s, "broken pipe") ||
+		strings.Contains(s, "connection reset") ||
+		strings.Contains(s, "connection refused") ||
+		errors.Is(err, io.ErrClosedPipe)
+}
+
 // CallTool executes a tool on the appropriate server
 func (c *Client) CallTool(ctx context.Context, toolName string, args map[string]interface{}) (*CallToolResult, error) {
+	result, err := c.callToolOnce(ctx, toolName, args)
+	if err == nil {
+		return result, nil
+	}
+
+	// On connection error, try to reconnect and retry once
+	if isConnectionError(err) {
+		c.mu.Lock()
+		var serverName string
+		var serverCfg config.MCPServer
+		for name, conn := range c.servers {
+			for _, tool := range conn.tools {
+				if tool.Name == toolName {
+					serverName = name
+					serverCfg = conn.config
+					break
+				}
+			}
+			if serverName != "" {
+				break
+			}
+		}
+		if serverName != "" {
+			if conn, exists := c.servers[serverName]; exists {
+				conn.Close()
+				delete(c.servers, serverName)
+			}
+		}
+		c.mu.Unlock()
+
+		if serverName != "" {
+			if reconnectErr := c.Connect(ctx, serverCfg); reconnectErr == nil {
+				if c.OnReconnect != nil {
+					c.OnReconnect(serverName)
+				}
+				return c.callToolOnce(ctx, toolName, args)
+			}
+		}
+	}
+
+	return nil, err
+}
+
+// callToolOnce executes a tool on the appropriate server (no retry)
+func (c *Client) callToolOnce(ctx context.Context, toolName string, args map[string]interface{}) (*CallToolResult, error) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
-	// Find which server has this tool
 	for _, conn := range c.servers {
 		for _, tool := range conn.tools {
 			if tool.Name == toolName {
@@ -331,25 +396,58 @@ func (conn *ServerConnection) sendRequest(ctx context.Context, method string, pa
 		return nil, fmt.Errorf("failed to write request: %w", err)
 	}
 
-	// Read response — goroutine will eventually unblock when connection closes.
-	// Channels are buffered so the goroutine can write and exit even if select returns first.
+	// Read response — skip notifications (messages with "method" but no "id") and
+	// only return the matching JSON-RPC response. Some MCP servers (e.g. kubernetes-mcp-server)
+	// send notifications like tools/list_changed which would otherwise be mistaken for responses.
 	responseChan := make(chan *JSONRPCResponse, 1)
 	errChan := make(chan error, 1)
 
 	go func() {
-		if conn.scanner.Scan() {
+		for {
+			if !conn.scanner.Scan() {
+				if err := conn.scanner.Err(); err != nil {
+					errChan <- fmt.Errorf("scanner error: %w", err)
+				} else {
+					msg := "connection closed"
+					if conn.stderrBuf != nil && conn.stderrBuf.Len() > 0 {
+						stderr := strings.TrimSpace(conn.stderrBuf.String())
+						msg = fmt.Sprintf("connection closed (MCP server stderr: %s)", stderr)
+						// Always print to stderr so user sees it in terminal
+						fmt.Fprintf(os.Stderr, "[k13d] MCP server %s exited unexpectedly. stderr:\n%s\n", conn.config.Name, stderr)
+						log.Debugf("MCP server %s exited, stderr: %s", conn.config.Name, stderr)
+					} else {
+						fmt.Fprintf(os.Stderr, "[k13d] MCP server %s connection closed (no stderr output)\n", conn.config.Name)
+					}
+					errChan <- fmt.Errorf("%s", msg)
+				}
+				return
+			}
+			line := conn.scanner.Bytes()
+
+			// Check if it's a notification (has "method" but no "id") — skip it
+			var raw map[string]json.RawMessage
+			if err := json.Unmarshal(line, &raw); err != nil {
+				errChan <- fmt.Errorf("failed to unmarshal: %w", err)
+				return
+			}
+			if _, hasMethod := raw["method"]; hasMethod {
+				if _, hasID := raw["id"]; !hasID {
+					continue // notification — skip and read next
+				}
+			}
+
+			// Parse as response and verify ID matches
 			var resp JSONRPCResponse
-			if err := json.Unmarshal(conn.scanner.Bytes(), &resp); err != nil {
+			if err := json.Unmarshal(line, &resp); err != nil {
 				errChan <- fmt.Errorf("failed to unmarshal response: %w", err)
 				return
 			}
-			responseChan <- &resp
-		} else {
-			if err := conn.scanner.Err(); err != nil {
-				errChan <- fmt.Errorf("scanner error: %w", err)
-			} else {
-				errChan <- fmt.Errorf("connection closed")
+			if resp.ID == reqID {
+				responseChan <- &resp
+				return
 			}
+			// ID mismatch — skip (could be stray message) and continue
+			continue
 		}
 	}()
 
@@ -430,6 +528,12 @@ func (conn *ServerConnection) listTools(ctx context.Context) error {
 
 // callTool executes a tool on this server
 func (conn *ServerConnection) callTool(ctx context.Context, name string, args map[string]interface{}) (*CallToolResult, error) {
+	// Some MCP servers crash when "arguments" is missing/null for no-arg tools.
+	// Always send an object ({} at minimum).
+	if args == nil {
+		args = map[string]interface{}{}
+	}
+
 	params := CallToolParams{
 		Name:      name,
 		Arguments: args,

--- a/pkg/web/server.go
+++ b/pkg/web/server.go
@@ -371,6 +371,11 @@ func newServer(cfg *config.Config, port int, authConfig *AuthConfig, embeddedLLM
 	}
 	fmt.Printf("  Security Scanner: Ready (%s)\n", scannerInfo)
 
+	// Set MCP reconnect callback to re-register tools when connection is restored
+	server.mcpClient.OnReconnect = func(serverName string) {
+		server.registerMCPTools(serverName)
+	}
+
 	// Initialize MCP servers
 	server.initMCPServers()
 


### PR DESCRIPTION
## MCP 도구 호출 안정성 및 정확도 개선

### 요약
Kubernetes MCP Server 등 외부 MCP 서버와의 연동 시 발생하던 크래시 및 타임아웃 문제를 수정

---

### 변경 사항

#### 1. Arguments 필드 항상 전송 (핵심 수정)
- **문제**: `namespaces_list`처럼 인자가 없는 도구 호출 시 `arguments` 필드가 JSON에서 생략되어, kubernetes-mcp-server(v0.0.57)가 파싱 중 panic으로 크래시
- **수정**: `CallToolParams.Arguments`의 `omitempty` 제거, `args == nil`일 때 빈 객체 `{}`로 초기화
- **파일**: `pkg/mcp/client.go`

#### 2. JSON-RPC Notification 스킵
- **문제**: MCP 서버가 `tools/list_changed` 등 notification을 보내면, 이를 응답으로 잘못 처리해 타임아웃/에러 발생
- **수정**: `method`는 있고 `id`는 없는 메시지는 notification으로 간주하고 스킵, 실제 응답(`id` 일치)만 처리
- **파일**: `pkg/mcp/client.go`

#### 3. JSONRPCNotification 타입 및 env 처리
- **수정**: JSON-RPC 2.0 스펙에 맞게 notification용 `JSONRPCNotification` 타입 추가 (id 필드 없음)
- **수정**: config의 빈 env 값으로 시스템 환경변수(GITHUB_PAT 등)를 덮어쓰지 않도록 변경
- **파일**: `pkg/mcp/client.go`

#### 4. OnReconnect 콜백 및 재연결
- **문제**: MCP 서버 연결이 끊긴 뒤 도구 재등록이 되지 않아 이후 호출 실패
- **수정**: `OnReconnect` 콜백 추가, 연결 오류 시 재연결 후 1회 재시도
- **파일**: `pkg/mcp/client.go`, `pkg/web/server.go`

#### 5. ToolNameInstruction 추가
- **문제**: LLM이 `pod_list`처럼 잘못된 도구 이름을 사용해 "Unknown tool" 에러 발생
- **수정**: MCP 도구가 있을 때만 스키마의 정확한 도구 이름 사용을 유도하는 지시문 추가
- **파일**: `pkg/ai/client.go`, `pkg/ai/agent/conversation.go`, `pkg/ai/tools/tools.go`

#### 6. Unknown tool 에러 메시지 개선
- **수정**: "Unknown tool: X. Use only the exact tool names from the function schema. Retry with the correct name." 형태로 안내 강화
- **파일**: `pkg/ai/tools/tools.go`

#### 7. MCP 도구 UI 표시 개선
- **문제**: MCP 도구 호출 시 실행 결과와 승인 모달에 `$ N/A` 또는 빈칸으로 표시됨
- **수정**: `command` 필드가 없는 MCP 도구는 `도구이름 + 인자` 형태로 표시 (예: `helm_list {}`, `pods_list {"namespace":"default"}`)
- **파일**: `pkg/ai/client.go`, `pkg/web/handlers_ai.go`
---
### 테스트 이미지
api키 한도라서 오류가 발생했지만, 문제없습니다! 
<img width="616" height="678" alt="image" src="https://github.com/user-attachments/assets/e6687944-5e11-4b23-9950-e2ef6c03ea5c" />
