### PR TITLE
fix(web): timeoutMiddleware race condition 제거

### DIFF
--- a/pkg/web/server.go
+++ b/pkg/web/server.go
@@ -667,10 +667,12 @@ func timeoutMiddleware(timeout time.Duration) func(http.Handler) http.Handler {
 				dw.mu.Lock()
 				dw.timedOut = true
 				headerSent := dw.headerSent
-				dw.mu.Unlock()
 				if !headerSent && ctx.Err() == context.DeadlineExceeded {
-					WriteError(w, NewAPIError(ErrCodeTimeout, "Request timed out"))
+					dw.ResponseWriter.Header().Set("Content-Type", "application/json")
+					dw.ResponseWriter.WriteHeader(http.StatusGatewayTimeout)
+					_ = json.NewEncoder(dw.ResponseWriter).Encode(NewAPIError(ErrCodeTimeout, "Request timed out"))
 				}
+				dw.mu.Unlock()
 			}
 		})
 	}


### PR DESCRIPTION
## 요약
웹 서버 타임아웃 처리 시 발생하던 `concurrent map iteration and map write` / `concurrent map writes` 패닉을 제거.

## 문제
- `./k13d -web -auth-mode local` 실행 중 위 패닉이 발생할 수 있음
- **원인**: `timeoutMiddleware`가 요청을 별도 고루틴에서 처리하는데, 타임아웃 시 메인 고루틴에서 `WriteError(w, ...)`를 호출하면서 handler 고루틴과 **같은 `http.Header`(map)에 동시 접근** 발생

## 수정 내용
- **파일**: `pkg/web/server.go` — `timeoutMiddleware` 내 `case <-ctx.Done():` 블록
- 타임아웃 응답을 **`WriteError(w)` 대신** lock 안에서 직접 처리:
  - `dw.mu.Lock()` ~ `dw.mu.Unlock()` 구간 안에서 `Header().Set`, `WriteHeader(504)`, JSON 인코딩 수행
- 이렇게 해서 타임아웃 응답을 쓰는 동안 handler는 lock으로 대기하게 되어, 동일 `ResponseWriter`/Header에 대한 동시 접근 제거