### PR TITLE
fix(ai): strip unsupported schema keys for Gemini tool declarations

### DIFF
--- a/pkg/ai/providers/gemini.go
+++ b/pkg/ai/providers/gemini.go
@@ -279,15 +279,54 @@ func (p *GeminiProvider) ListModels(ctx context.Context) ([]string, error) {
 	return models, nil
 }
 
+// sanitizeSchemaForGemini returns a copy of the schema with fields that Gemini API
+// does not accept removed ($schema, additionalProperties, default, minimum, maximum).
+func sanitizeSchemaForGemini(in map[string]interface{}) map[string]interface{} {
+	if in == nil {
+		return nil
+	}
+	disallowed := map[string]bool{
+		"$schema":              true,
+		"additionalProperties": true,
+		"default":              true,
+		"minimum":              true,
+		"maximum":              true,
+	}
+	out := make(map[string]interface{}, len(in))
+	for k, v := range in {
+		if disallowed[k] {
+			continue
+		}
+		out[k] = sanitizeSchemaValueForGemini(v)
+	}
+	return out
+}
+
+func sanitizeSchemaValueForGemini(v interface{}) interface{} {
+	switch t := v.(type) {
+	case map[string]interface{}:
+		return sanitizeSchemaForGemini(t)
+	case []interface{}:
+		arr := make([]interface{}, len(t))
+		for i, el := range t {
+			arr[i] = sanitizeSchemaValueForGemini(el)
+		}
+		return arr
+	default:
+		return v
+	}
+}
+
 // AskWithTools implements ToolProvider for Gemini using functionDeclarations/functionCall.
 func (p *GeminiProvider) AskWithTools(ctx context.Context, prompt string, tools []ToolDefinition, callback func(string), toolCallback ToolCallback) error {
-	// Convert tools to Gemini format
+	// Convert tools to Gemini format (sanitize parameters so Gemini API accepts the schema)
 	var funcDecls []geminiFuncDecl
 	for _, tool := range tools {
+		params := sanitizeSchemaForGemini(tool.Function.Parameters)
 		funcDecls = append(funcDecls, geminiFuncDecl{
 			Name:        tool.Function.Name,
 			Description: tool.Function.Description,
-			Parameters:  tool.Function.Parameters,
+			Parameters:  params,
 		})
 	}
 


### PR DESCRIPTION
## 요약
Gemini + MCP 도구 호출 시, Gemini API가 지원하지 않는 JSON Schema 필드 때문에 발생하던 `400 Bad Request` 방지

## 문제
- MCP 도구 정의를 그대로 Gemini `functionDeclarations`의 `parameters`로 전달할 때,
  - `$schema`
  - `additionalProperties`
  - `default`
  - `minimum`
  - `maximum`
- 등의 필드가 포함되어 있으면 Gemini API가 이를 허용하지 않아 `400 Bad Request`를 반환

## 해결 방법
- **파일**: `pkg/ai/providers/gemini.go`
- **변경 내용**:
  - `sanitizeSchemaForGemini` / `sanitizeSchemaValueForGemini` 함수 추가
    - 위에서 언급한 Gemini 비호환 필드(`$schema`, `additionalProperties`, `default`, `minimum`, `maximum`)를 재귀적으로 제거
  - `AskWithTools`에서 `tool.Function.Parameters`를 그대로 쓰지 않고,
    - `sanitizeSchemaForGemini(tool.Function.Parameters)` 결과를 `Parameters`로 사용

## 영향 범위
- 변경 대상은 **Gemini Provider의 도구 호출 경로에만 한정**
- 다른 Provider(OpenAI 등)나 일반 텍스트 호출(`Ask`, `AskNonStreaming`)에는 영향이 없음
