### PR TITLE
feat(ai,web): show MCP tool server and type in debug UI

### DIFF
--- a/pkg/ai/client.go
+++ b/pkg/ai/client.go
@@ -215,9 +215,11 @@ func GetAvailableProviders() string {
 	return providers.GetFactory().ListProviders()
 }
 
-// ToolExecutionCallback is called when a tool is executed
-// It receives the tool name, command, and result
-type ToolExecutionCallback func(toolName string, command string, result string, isError bool)
+// ToolExecutionCallback is called when a tool is executed.
+// It receives the tool name, command, result, error flag, and optional metadata about the tool.
+// toolType is one of the ToolType string values (kubectl, bash, mcp, etc.).
+// toolServerName is populated for MCP tools to indicate which MCP server provided the tool.
+type ToolExecutionCallback func(toolName string, command string, result string, isError bool, toolType string, toolServerName string)
 
 // AskWithTools sends a prompt with tool calling support (agentic mode)
 // The toolApprovalCallback is called before executing each tool for user approval
@@ -266,7 +268,9 @@ func (c *Client) AskWithToolsAndExecution(ctx context.Context, prompt string, ca
 		if toolApprovalCallback != nil {
 			if !toolApprovalCallback(call.Function.Name, call.Function.Arguments) {
 				if toolExecutionCallback != nil {
-					toolExecutionCallback(call.Function.Name, command, "Tool execution cancelled by user", true)
+					// Best-effort lookup of tool metadata for callbacks
+					toolType, toolServerName := c.getToolMetadata(call.Function.Name)
+					toolExecutionCallback(call.Function.Name, command, "Tool execution cancelled by user", true, toolType, toolServerName)
 				}
 				return providers.ToolResult{
 					ToolCallID: call.ID,
@@ -290,7 +294,8 @@ func (c *Client) AskWithToolsAndExecution(ctx context.Context, prompt string, ca
 
 		// Notify about tool execution result
 		if toolExecutionCallback != nil {
-			toolExecutionCallback(call.Function.Name, command, result.Content, result.IsError)
+			toolType, toolServerName := c.getToolMetadata(call.Function.Name)
+			toolExecutionCallback(call.Function.Name, command, result.Content, result.IsError, toolType, toolServerName)
 		}
 
 		return providers.ToolResult{
@@ -307,6 +312,19 @@ func (c *Client) AskWithToolsAndExecution(ctx context.Context, prompt string, ca
 	}
 
 	return toolProvider.AskWithTools(ctx, prompt, toolDefs, callback, toolCallback)
+}
+
+// getToolMetadata returns lightweight metadata about a tool from the registry for callbacks.
+// It is best-effort and falls back to empty strings if the tool is unknown.
+func (c *Client) getToolMetadata(toolName string) (toolType string, toolServerName string) {
+	if c.toolRegistry == nil {
+		return "", ""
+	}
+	tool, ok := c.toolRegistry.Get(toolName)
+	if !ok || tool == nil {
+		return "", ""
+	}
+	return string(tool.Type), tool.ServerName
 }
 
 // SupportsTools returns true if the current provider supports tool calling

--- a/pkg/web/handlers_ai.go
+++ b/pkg/web/handlers_ai.go
@@ -547,13 +547,15 @@ func (s *Server) handleAgenticChat(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Tool execution callback - sends tool execution info via SSE and records audit
-	toolExecutionCallback := func(toolName string, command string, result string, isError bool) {
+	toolExecutionCallback := func(toolName string, command string, result string, isError bool, toolType string, toolServerName string) {
 		execJSON, _ := json.Marshal(map[string]interface{}{
-			"type":     "tool_execution",
-			"tool":     toolName,
-			"command":  command,
-			"result":   result,
-			"is_error": isError,
+			"type":      "tool_execution",
+			"tool":      toolName,
+			"tool_type": toolType,
+			"server":    toolServerName,
+			"command":   command,
+			"result":    result,
+			"is_error":  isError,
 		})
 		_ = sse.WriteEvent("tool_execution", string(execJSON))
 

--- a/pkg/web/static/js/app.js
+++ b/pkg/web/static/js/app.js
@@ -2331,10 +2331,19 @@ function showToolExecution(execInfo, messageDiv, contentEl) {
     const uniqueId = 'tool-result-' + Date.now();
     const resultLength = execInfo.result ? execInfo.result.length : 0;
 
+    const toolLabelParts = [];
+    if (execInfo.tool) {
+        toolLabelParts.push(execInfo.tool);
+    }
+    if (execInfo.server) {
+        toolLabelParts.push(`(${execInfo.server})`);
+    }
+    const toolLabel = toolLabelParts.join(' ');
+
     execDiv.innerHTML = `
                 <div class="tool-header" style="display: flex; align-items: center; gap: 8px; margin-bottom: 6px;">
                     <span style="color: ${statusColor};">${statusIcon}</span>
-                    <span class="tool-name">${execInfo.tool}</span>
+                    <span class="tool-name">${toolLabel}</span>
                 </div>
                 <div class="tool-command" style="background: var(--bg-primary); padding: 8px; border-radius: 4px; font-family: monospace; font-size: 12px; margin-bottom: 8px; word-break: break-all;">
                     $ ${escapeHtml(execInfo.command || 'N/A')}
@@ -2357,6 +2366,8 @@ ${escapeHtml(execInfo.result)}</div>
     // Log to debug panel
     addDebugLog('tool', 'Tool Executed', {
         tool: execInfo.tool,
+        tool_type: execInfo.tool_type,
+        server: execInfo.server,
         command: execInfo.command,
         result_length: resultLength,
         is_error: isError


### PR DESCRIPTION
## 요약
- AI 도구 실행 시 어떤 MCP 서버의 어느 툴이 호출됐는지 디버그 모드에서 확인할 수 있도록 했습니다.

## 변경 내용
- `ToolExecutionCallback`에 `tool_type`, `tool_server_name` 메타데이터 추가
- `tool_execution` SSE 이벤트에 `tool_type`, `server` 필드 포함
- 웹 디버그 패널 및 툴 실행 카드에서 `search_users (user-github-mcp-server)` 형태로 MCP 서버/툴 타입 표시

## 결과
<img width="434" height="240" alt="image" src="https://github.com/user-attachments/assets/e082f834-7db0-427c-9d94-e73f5a612b98" />

server 필드의 정보는 사용자가 추가한 mpc 서버 명으로 출력됩니다.  제가 사용한 이름은 다음과 같습니다.

<img width="630" height="298" alt="image" src="https://github.com/user-attachments/assets/cc840d49-8ccc-423a-b1e1-63bdc1763a76" />
