### PR TITLE
feat: Disable and focus AI input during message processing and reloca…

### DIFF
--- a/pkg/web/static/js/app.js
+++ b/pkg/web/static/js/app.js
@@ -2087,9 +2087,11 @@ function stopGeneration() {
 async function proceedWithMessage(message) {
     isLoading = true;
     const sendBtn = document.getElementById('send-btn');
+    const aiInput = document.getElementById('ai-input');
     if (sendBtn) sendBtn.disabled = true;
+    aiInput.value = '';
+    aiInput.disabled = true;
 
-    document.getElementById('ai-input').value = '';
     saveQueryToHistory(message);
     aiHistoryIndex = -1;
     aiCurrentDraft = '';
@@ -2104,6 +2106,8 @@ async function proceedWithMessage(message) {
     } finally {
         isLoading = false;
         if (sendBtn) sendBtn.disabled = false;
+        aiInput.disabled = false;
+        aiInput.focus();
     }
 }
 
@@ -8730,9 +8734,15 @@ sendMessage = async function () {
     // Log request in debug mode
     addDebugLog('request', 'AI Request', { message, context: aiContextItems });
 
+    // Save query to history for arrow key navigation
+    saveQueryToHistory(message.split('\n\nContext from selected resources:')[0]);
+    aiHistoryIndex = -1;
+    aiCurrentDraft = '';
+
     isLoading = true;
     document.getElementById('send-btn').disabled = true;
     input.value = '';
+    input.disabled = true;
 
     addMessage(message.split('\n\nContext from selected resources:')[0], true);
 
@@ -8741,6 +8751,8 @@ sendMessage = async function () {
 
     isLoading = false;
     document.getElementById('send-btn').disabled = false;
+    input.disabled = false;
+    input.focus();
 };
 
 // ==========================================


### PR DESCRIPTION
<!-- One-line description of what this PR does and why. -->
AI 입력창 사용성 개선: 히스토리 저장 로직 수정 및 처리 중 입력 필드 제어
## Changes
<!-- Bullet list of what changed. -->
- **입력 히스토리(방향키 탐색) 기능 복구**
  - 메시지 전송 시 [saveQueryToHistory()](cci:1://file:///Users/chime/develop/go/k13d/pkg/web/static/js/app.js:2644:0-2652:1) 호출이 누락되어 상하 방향키를 통한 이전 질문 검색이 동작하지 않던 문제를 해결했습니다.
  - 전송 시 히스토리 인덱스(`aiHistoryIndex`)와 임시 입력값(`aiCurrentDraft`)을 초기화하여 탐색 로직이 정상적으로 작동하도록 수정했습니다.
- **AI 응답 생성 중 입력 제어**
  - AI가 응답을 생성하는 동안 사용자 혼선을 방지하기 위해 입력창(`ai-input`)을 비활성화(`disabled`) 처리하고 입력된 값을 비웁니다.
  - 응답 생성이 완료되거나 중단되면 입력창을 다시 활성화하고, 즉시 다음 질문을 입력할 수 있도록 자동으로 포커스(`focus`)를 부여합니다.
## Type
<!-- Check the one that applies. -->
- [x] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `docs` — Documentation only
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] [test](cci:1://file:///Users/chime/develop/go/k13d/pkg/web/static/js/app.js:11128:0-11148:1) — Adding or updating tests
- [ ] `chore` — Build, CI, or dependency update
## Testing
<!-- How did you verify this works? -->
- [x] Manual TUI / Web UI testing
  - 질문 전송 후 상하 방향키를 눌러 이전 질문들이 정상적으로 표시되는지 확인했습니다.
  - AI 응답이 생성되는 동안 입력창이 비활성화되어 추가 입력이 차단되는지 확인했습니다.
  - 응답 완료 후 입력창이 활성화되며 포커스가 자동으로 잡히는지 확인했습니다.
## Checklist
- [x] No new lint warnings
- [ ] PR targets `dev` branch (not `main`)