### PR TITLE
fix(web): serve frontend bundle fallback in release binaries

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -8,6 +8,7 @@ before:
   hooks:
     - go mod tidy
     - go generate ./...
+    - go run scripts/build-frontend.go
     - bash scripts/download-trivy.sh
     - bash scripts/package-helm.sh {{ .Version }}
 

--- a/pkg/web/frontendbundle/bundle.go
+++ b/pkg/web/frontendbundle/bundle.go
@@ -1,0 +1,107 @@
+package frontendbundle
+
+import (
+	"bytes"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+// CSSFiles defines the bundle order for stylesheet assets under pkg/web/static.
+var CSSFiles = []string{
+	"css/variables.css",
+	"css/base.css",
+	"css/components.css",
+	"css/layout.css",
+	"css/views.css",
+	"css/views/overview.css",
+	"css/views/custom-views.css",
+	"css/views/settings.css",
+	"css/views/theme-light.css",
+	"css/views/responsive.css",
+	"css/animations.css",
+}
+
+// JSFiles defines the bundle order for JavaScript assets under pkg/web/static.
+var JSFiles = []string{
+	"js/core/utils.js",
+	"js/modules/i18n.js",
+	"js/modules/VirtualScroller.js",
+	"js/modules/api.js",
+	"js/modules/swr.js",
+	"js/app.js",
+	"js/features/custom-views/shared.js",
+	"js/features/custom-views/metrics.js",
+	"js/features/custom-views/topology-tree.js",
+	"js/features/custom-views/applications.js",
+	"js/features/custom-views/cluster-context.js",
+	"js/features/ai-settings.js",
+	"js/features/settings.js",
+	"js/features/notifications.js",
+	"js/features/insights.js",
+	"js/features/workspace.js",
+	"js/bootstrap.js",
+}
+
+// BuildCSSBundle builds bundle.css content from a static asset filesystem.
+func BuildCSSBundle(fsys fs.FS) ([]byte, error) {
+	return buildBundle(fsys, CSSFiles, "/* ", " */")
+}
+
+// BuildJSBundle builds bundle.js content from a static asset filesystem.
+func BuildJSBundle(fsys fs.FS) ([]byte, error) {
+	return buildBundle(fsys, JSFiles, "// ", "")
+}
+
+// WriteBundles writes bundle.css and bundle.js into the given static directory.
+func WriteBundles(staticDir string) error {
+	fsys := os.DirFS(staticDir)
+
+	cssBundle, err := BuildCSSBundle(fsys)
+	if err != nil {
+		return fmt.Errorf("build CSS bundle: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(staticDir, "bundle.css"), cssBundle, 0o644); err != nil {
+		return fmt.Errorf("write bundle.css: %w", err)
+	}
+
+	jsBundle, err := BuildJSBundle(fsys)
+	if err != nil {
+		return fmt.Errorf("build JS bundle: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(staticDir, "bundle.js"), jsBundle, 0o644); err != nil {
+		return fmt.Errorf("write bundle.js: %w", err)
+	}
+
+	return nil
+}
+
+func buildBundle(fsys fs.FS, files []string, commentStart, commentEnd string) ([]byte, error) {
+	var buf bytes.Buffer
+	filesIncluded := 0
+
+	buf.WriteString(fmt.Sprintf("%sk13d Frontend Bundle%s\n", commentStart, commentEnd))
+	buf.WriteString(fmt.Sprintf("%sGenerated from embedded modular assets%s\n\n", commentStart, commentEnd))
+
+	for _, file := range files {
+		content, err := fs.ReadFile(fsys, file)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return nil, fmt.Errorf("read %s: %w", file, err)
+		}
+
+		buf.WriteString(fmt.Sprintf("%s=== %s ===%s\n", commentStart, file, commentEnd))
+		buf.Write(content)
+		buf.WriteByte('\n')
+		filesIncluded++
+	}
+
+	if filesIncluded == 0 {
+		return nil, fmt.Errorf("no source files found")
+	}
+
+	return buf.Bytes(), nil
+}

--- a/pkg/web/frontendbundle/bundle_test.go
+++ b/pkg/web/frontendbundle/bundle_test.go
@@ -1,0 +1,47 @@
+package frontendbundle
+
+import (
+	"strings"
+	"testing"
+	"testing/fstest"
+)
+
+func TestBuildCSSBundle(t *testing.T) {
+	fsys := fstest.MapFS{
+		"css/variables.css": &fstest.MapFile{Data: []byte(":root { --bg: #000; }\n")},
+		"css/base.css":      &fstest.MapFile{Data: []byte("body { background: var(--bg); }\n")},
+	}
+
+	bundle, err := BuildCSSBundle(fsys)
+	if err != nil {
+		t.Fatalf("BuildCSSBundle() error = %v", err)
+	}
+
+	got := string(bundle)
+	if !strings.Contains(got, "css/variables.css") || !strings.Contains(got, "css/base.css") {
+		t.Fatalf("bundle missing expected file markers:\n%s", got)
+	}
+	if strings.Index(got, "css/variables.css") > strings.Index(got, "css/base.css") {
+		t.Fatalf("expected variables.css before base.css:\n%s", got)
+	}
+}
+
+func TestBuildJSBundle(t *testing.T) {
+	fsys := fstest.MapFS{
+		"js/app.js":       &fstest.MapFile{Data: []byte("window.app = true;\n")},
+		"js/bootstrap.js": &fstest.MapFile{Data: []byte("window.boot = true;\n")},
+	}
+
+	bundle, err := BuildJSBundle(fsys)
+	if err != nil {
+		t.Fatalf("BuildJSBundle() error = %v", err)
+	}
+
+	got := string(bundle)
+	if !strings.Contains(got, "js/app.js") || !strings.Contains(got, "js/bootstrap.js") {
+		t.Fatalf("bundle missing expected file markers:\n%s", got)
+	}
+	if strings.Index(got, "js/app.js") > strings.Index(got, "js/bootstrap.js") {
+		t.Fatalf("expected app.js before bootstrap.js:\n%s", got)
+	}
+}

--- a/pkg/web/server.go
+++ b/pkg/web/server.go
@@ -23,10 +23,16 @@ import (
 	"github.com/cloudbro-kube-ai/k13d/pkg/mcp"
 	"github.com/cloudbro-kube-ai/k13d/pkg/metrics"
 	"github.com/cloudbro-kube-ai/k13d/pkg/security"
+	"github.com/cloudbro-kube-ai/k13d/pkg/web/frontendbundle"
 )
 
 //go:embed static/*
 var staticFiles embed.FS
+
+var (
+	embeddedBundleMu sync.Mutex
+	embeddedBundles  = map[string][]byte{}
+)
 
 // VersionInfo holds build version information
 type VersionInfo struct {
@@ -631,19 +637,13 @@ func (s *Server) Start() error {
 	staticFS, err := fs.Sub(staticFiles, "static")
 	var staticHandler http.Handler
 	if err != nil {
-		staticHandler = http.FileServer(http.Dir("pkg/web/static"))
-	} else {
-		staticHandler = http.FileServer(http.FS(staticFS))
+		return fmt.Errorf("prepare embedded static filesystem: %w", err)
 	}
+	staticHandler = http.FileServer(http.FS(staticFS))
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		// For index.html (root path), inject auth mode as inline script
 		if r.URL.Path == "/" || r.URL.Path == "/index.html" {
-			var indexData []byte
-			if err != nil {
-				indexData, _ = os.ReadFile("pkg/web/static/index.html")
-			} else {
-				indexData, _ = fs.ReadFile(staticFiles, "static/index.html")
-			}
+			indexData, _ := fs.ReadFile(staticFS, "index.html")
 			if indexData != nil {
 				authMode := s.authManager.GetAuthMode()
 				html := string(indexData)
@@ -661,6 +661,10 @@ func (s *Server) Start() error {
 				_, _ = w.Write([]byte(html))
 				return
 			}
+		}
+
+		if serveGeneratedBundle(w, r, staticFS) {
+			return
 		}
 		staticHandler.ServeHTTP(w, r)
 	})
@@ -694,6 +698,63 @@ func (s *Server) Start() error {
 
 	fmt.Printf("\n  Web server started at http://localhost:%d\n", s.port)
 	return s.server.ListenAndServe()
+}
+
+func serveGeneratedBundle(w http.ResponseWriter, r *http.Request, staticFS fs.FS) bool {
+	var (
+		bundleName  string
+		contentType string
+		builder     func(fs.FS) ([]byte, error)
+	)
+
+	switch r.URL.Path {
+	case "/bundle.css":
+		bundleName = "bundle.css"
+		contentType = "text/css; charset=utf-8"
+		builder = frontendbundle.BuildCSSBundle
+	case "/bundle.js":
+		bundleName = "bundle.js"
+		contentType = "application/javascript; charset=utf-8"
+		builder = frontendbundle.BuildJSBundle
+	default:
+		return false
+	}
+
+	// Prefer prebuilt bundles when they were embedded at build time.
+	if content, err := fs.ReadFile(staticFS, bundleName); err == nil {
+		w.Header().Set("Content-Type", contentType)
+		w.Header().Set("Cache-Control", "public, max-age=300")
+		_, _ = w.Write(content)
+		return true
+	}
+
+	content, err := cachedGeneratedBundle(bundleName, staticFS, builder)
+	if err != nil {
+		http.Error(w, "frontend bundle unavailable", http.StatusInternalServerError)
+		return true
+	}
+
+	w.Header().Set("Content-Type", contentType)
+	w.Header().Set("Cache-Control", "public, max-age=300")
+	_, _ = w.Write(content)
+	return true
+}
+
+func cachedGeneratedBundle(name string, staticFS fs.FS, builder func(fs.FS) ([]byte, error)) ([]byte, error) {
+	embeddedBundleMu.Lock()
+	defer embeddedBundleMu.Unlock()
+
+	if content, ok := embeddedBundles[name]; ok {
+		return content, nil
+	}
+
+	content, err := builder(staticFS)
+	if err != nil {
+		return nil, err
+	}
+
+	embeddedBundles[name] = content
+	return content, nil
 }
 
 func (s *Server) Stop() error {

--- a/pkg/web/server_bundle_test.go
+++ b/pkg/web/server_bundle_test.go
@@ -1,0 +1,61 @@
+package web
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"testing/fstest"
+)
+
+func TestServeGeneratedBundle_FallbackCSS(t *testing.T) {
+	resetGeneratedBundleCache()
+
+	req := httptest.NewRequest(http.MethodGet, "/bundle.css", nil)
+	w := httptest.NewRecorder()
+
+	staticFS := fstest.MapFS{
+		"css/variables.css": &fstest.MapFile{Data: []byte(":root { --bg: #000; }\n")},
+		"css/base.css":      &fstest.MapFile{Data: []byte("body { background: var(--bg); }\n")},
+	}
+
+	if !serveGeneratedBundle(w, req, staticFS) {
+		t.Fatal("serveGeneratedBundle() = false, want true")
+	}
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+	if got := w.Header().Get("Content-Type"); got != "text/css; charset=utf-8" {
+		t.Fatalf("Content-Type = %q, want text/css; charset=utf-8", got)
+	}
+	if body := w.Body.String(); body == "" {
+		t.Fatal("expected generated CSS bundle body")
+	}
+}
+
+func TestServeGeneratedBundle_UsesPrebuiltBundle(t *testing.T) {
+	resetGeneratedBundleCache()
+
+	req := httptest.NewRequest(http.MethodGet, "/bundle.js", nil)
+	w := httptest.NewRecorder()
+
+	staticFS := fstest.MapFS{
+		"bundle.js": &fstest.MapFile{Data: []byte("console.log('prebuilt');\n")},
+		"js/app.js": &fstest.MapFile{Data: []byte("console.log('fallback');\n")},
+	}
+
+	if !serveGeneratedBundle(w, req, staticFS) {
+		t.Fatal("serveGeneratedBundle() = false, want true")
+	}
+	if got := w.Header().Get("Content-Type"); got != "application/javascript; charset=utf-8" {
+		t.Fatalf("Content-Type = %q, want application/javascript; charset=utf-8", got)
+	}
+	if got := w.Body.String(); got != "console.log('prebuilt');\n" {
+		t.Fatalf("body = %q, want prebuilt bundle", got)
+	}
+}
+
+func resetGeneratedBundleCache() {
+	embeddedBundleMu.Lock()
+	defer embeddedBundleMu.Unlock()
+	embeddedBundles = map[string][]byte{}
+}

--- a/scripts/build-frontend.go
+++ b/scripts/build-frontend.go
@@ -13,170 +13,28 @@
 package main
 
 import (
-	"bytes"
 	"fmt"
 	"os"
-	"path/filepath"
-	"strings"
 	"time"
+
+	"github.com/cloudbro-kube-ai/k13d/pkg/web/frontendbundle"
 )
 
 const (
 	staticDir = "pkg/web/static"
-	cssDir    = "pkg/web/static/css"
-	jsDir     = "pkg/web/static/js"
 )
-
-// CSS files in order of inclusion
-var cssFiles = []string{
-	"css/variables.css",
-	"css/base.css",
-	"css/components.css",
-	"css/layout.css",
-	"css/views.css",
-	"css/views/overview.css",
-	"css/views/custom-views.css",
-	"css/views/settings.css",
-	"css/views/theme-light.css",
-	"css/views/responsive.css",
-	"css/animations.css",
-}
-
-// JS files in order of inclusion (dependencies first)
-var jsFiles = []string{
-	"js/core/utils.js",
-	"js/modules/i18n.js",
-	"js/modules/VirtualScroller.js",
-	"js/modules/api.js",
-	"js/modules/swr.js",
-	"js/app.js",
-	"js/features/custom-views/shared.js",
-	"js/features/custom-views/metrics.js",
-	"js/features/custom-views/topology-tree.js",
-	"js/features/custom-views/applications.js",
-	"js/features/custom-views/cluster-context.js",
-	"js/features/ai-settings.js",
-	"js/features/settings.js",
-	"js/features/notifications.js",
-	"js/features/insights.js",
-	"js/features/workspace.js",
-	"js/bootstrap.js",
-}
 
 func main() {
 	startTime := time.Now()
 	fmt.Println("🔨 Building frontend assets...")
 
-	// Check if we have modular source files
-	cssModular := hasModularFiles(cssDir)
-	jsModular := hasModularFiles(jsDir)
-
-	if !cssModular && !jsModular {
-		fmt.Println("ℹ️  No modular source files found.")
-		fmt.Println("   CSS/JS are still embedded in index.html")
-		fmt.Println("   Run 'make frontend-extract' to extract them first.")
-		return
-	}
-
-	var errors []string
-
-	// Bundle CSS
-	if cssModular {
-		if err := bundleFiles(cssFiles, filepath.Join(staticDir, "bundle.css"), "/* ", " */"); err != nil {
-			errors = append(errors, fmt.Sprintf("CSS bundle error: %v", err))
-		} else {
-			fmt.Println("✅ Created bundle.css")
-		}
-	}
-
-	// Bundle JS
-	if jsModular {
-		if err := bundleFiles(jsFiles, filepath.Join(staticDir, "bundle.js"), "// ", ""); err != nil {
-			errors = append(errors, fmt.Sprintf("JS bundle error: %v", err))
-		} else {
-			fmt.Println("✅ Created bundle.js")
-		}
-	}
-
-	// Report results
-	duration := time.Since(startTime)
-	if len(errors) > 0 {
-		fmt.Println("\n❌ Build completed with errors:")
-		for _, e := range errors {
-			fmt.Printf("   - %s\n", e)
-		}
+	if err := frontendbundle.WriteBundles(staticDir); err != nil {
+		fmt.Printf("\n❌ Build completed with error: %v\n", err)
 		os.Exit(1)
 	}
 
+	duration := time.Since(startTime)
+	fmt.Println("✅ Created bundle.css")
+	fmt.Println("✅ Created bundle.js")
 	fmt.Printf("\n✅ Build completed in %v\n", duration.Round(time.Millisecond))
-}
-
-// hasModularFiles checks if directory has any source files
-func hasModularFiles(dir string) bool {
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		return false
-	}
-	for _, e := range entries {
-		if !e.IsDir() && (strings.HasSuffix(e.Name(), ".css") || strings.HasSuffix(e.Name(), ".js")) {
-			return true
-		}
-		// Check subdirectories for js/
-		if e.IsDir() {
-			subDir := filepath.Join(dir, e.Name())
-			subEntries, err := os.ReadDir(subDir)
-			if err == nil {
-				for _, se := range subEntries {
-					if strings.HasSuffix(se.Name(), ".js") {
-						return true
-					}
-				}
-			}
-		}
-	}
-	return false
-}
-
-// bundleFiles concatenates multiple files into one bundle
-func bundleFiles(files []string, outputPath string, commentStart, commentEnd string) error {
-	var buf bytes.Buffer
-
-	// Write header
-	buf.WriteString(fmt.Sprintf("%sk13d Frontend Bundle - Generated at %s%s\n",
-		commentStart, time.Now().Format(time.RFC3339), commentEnd))
-	buf.WriteString(fmt.Sprintf("%sDO NOT EDIT - Modify source files in css/ or js/ directories%s\n\n",
-		commentStart, commentEnd))
-
-	filesIncluded := 0
-	for _, file := range files {
-		fullPath := filepath.Join(staticDir, file)
-
-		// Skip if file doesn't exist
-		if _, err := os.Stat(fullPath); os.IsNotExist(err) {
-			continue
-		}
-
-		// Read file
-		content, err := os.ReadFile(fullPath)
-		if err != nil {
-			return fmt.Errorf("failed to read %s: %w", file, err)
-		}
-
-		// Write file marker and content
-		buf.WriteString(fmt.Sprintf("\n%s=== %s ===%s\n", commentStart, file, commentEnd))
-		buf.Write(content)
-		buf.WriteString("\n")
-		filesIncluded++
-	}
-
-	if filesIncluded == 0 {
-		return fmt.Errorf("no source files found")
-	}
-
-	// Write output
-	if err := os.WriteFile(outputPath, buf.Bytes(), 0644); err != nil {
-		return fmt.Errorf("failed to write bundle: %w", err)
-	}
-
-	return nil
 }


### PR DESCRIPTION
## Summary
- generate `bundle.css` and `bundle.js` on demand from embedded modular assets when release binaries do not include the prebuilt bundles
- run `scripts/build-frontend.go` in GoReleaser before hooks so future release artifacts embed the bundles consistently
- add focused tests for bundle generation and bundle serving fallback

## Why
The `v1.0.0` release binary could start the Web UI server, but browsers received `404 text/plain` for `/bundle.css` and `/bundle.js`, which caused strict MIME errors and a broken page.

## Validation
- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `go build ./...`
- `make build`
- `golangci-lint run`
- manual smoke check: `GET /bundle.css` => `200 text/css`, `GET /bundle.js` => `200 application/javascript`
