### PR TITLE
feat: implement switchable TUI mode for host shell in AI panel

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -49,6 +49,7 @@ require (
 	github.com/containerd/errdefs v0.3.0 // indirect
 	github.com/containerd/log v0.1.0 // indirect
 	github.com/containerd/platforms v0.2.1 // indirect
+	github.com/creack/pty v1.1.24 // indirect
 	github.com/cyphar/filepath-securejoin v0.6.1 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect

--- a/pkg/web/authz.go
+++ b/pkg/web/authz.go
@@ -49,6 +49,7 @@ const (
 	FeatureSettingsAdmin    Feature = "settings_admin"
 	FeatureSettingsSecurity Feature = "settings_security"
 	FeatureSettingsNotif    Feature = "settings_notif"
+	FeatureHostTerminal     Feature = "host_terminal"
 )
 
 // AllFeatures returns all defined feature constants
@@ -62,6 +63,7 @@ func AllFeatures() []Feature {
 		FeatureNetworkPolicy, FeatureRBACViz,
 		FeatureSettingsGeneral, FeatureSettingsAdmin, FeatureSettingsSecurity,
 		FeatureSettingsNotif,
+		FeatureHostTerminal,
 	}
 }
 

--- a/pkg/web/routes.go
+++ b/pkg/web/routes.go
@@ -114,6 +114,7 @@ func (s *Server) registerK8sRoutes(mux *http.ServeMux) {
 	// WebSocket terminal (feature-gated)
 	terminalHandler := NewTerminalHandler(s.k8sClient)
 	mux.HandleFunc("/api/terminal/", auth(s.authorizer.FeatureMiddleware(FeatureTerminal)(terminalHandler.HandleTerminal)))
+	mux.HandleFunc("/api/tui/shell", auth(s.authorizer.FeatureMiddleware(FeatureHostTerminal)(s.HandleTUIShell)))
 
 	// GitOps status (ArgoCD / Flux)
 	mux.HandleFunc("/api/gitops/status", auth(s.handleGitOpsStatus))

--- a/pkg/web/static/css/views.css
+++ b/pkg/web/static/css/views.css
@@ -1842,6 +1842,49 @@
             display: none;
         }
 
+        .ai-header {
+            display: flex;
+            align-items: center;
+            padding: 10px 16px;
+            background: var(--surface-secondary);
+            border-bottom: 1px solid var(--border-color);
+            gap: 10px;
+            flex-shrink: 0;
+        }
+
+        .ai-mode-selector {
+            display: flex;
+            gap: 2px;
+            margin-left: 8px;
+            background: var(--bg-tertiary);
+            padding: 2px;
+            border-radius: 6px;
+            border: 1px solid rgba(122, 162, 247, 0.1);
+        }
+
+        .ai-mode-btn {
+            background: transparent;
+            border: none;
+            color: var(--text-secondary);
+            font-size: 11px;
+            padding: 3px 10px;
+            border-radius: 4px;
+            cursor: pointer;
+            transition: all 0.2s ease;
+            font-weight: 500;
+        }
+
+        .ai-mode-btn:hover {
+            color: var(--text-primary);
+            background: rgba(122, 162, 247, 0.1);
+        }
+
+        .ai-mode-btn.active {
+            background: var(--accent-blue);
+            color: #1a1b26;
+            font-weight: 600;
+        }
+
         .search-result-item {
             display: flex;
             align-items: center;

--- a/pkg/web/static/index.html
+++ b/pkg/web/static/index.html
@@ -783,9 +783,12 @@
                         <button class="chat-history-toggle" id="chat-history-toggle" onclick="toggleChatHistory()"
                             title="Chat History">📋</button>
                         <span>AI Assistant</span>
+                        <div class="ai-mode-selector">
+                            <button class="ai-mode-btn active" id="ai-btn-chat" onclick="setAIMode('chat')" title="Chat View">Chat</button>
+                            <button class="ai-mode-btn" id="ai-btn-tui" onclick="setAIMode('tui')" title="Terminal View">TUI</button>
+                        </div>
                         <span class="ai-status-dot" id="ai-status-dot" title="Checking connection...">●</span>
                         <span class="ai-badge" id="ai-model-badge" style="cursor:pointer;" onclick="openAIModelSettings()" title="Click to change model settings">Loading...</span>
-                        <!-- <span style="cursor:pointer;opacity:0.6;font-size:12px;" onclick="openAIModelSettings()" title="AI Model Settings">⚙️</span> -->
                         <button class="debug-toggle" id="debug-toggle" onclick="toggleDebugMode()"
                             style="margin-left: auto;" title="Toggle Debug Mode">🐛 Debug</button>
                     </div>
@@ -813,6 +816,15 @@
                                 <br>- "Scale deployment to 3 replicas"
                                 <br><br>
                                 <strong>Tip:</strong> Click any resource row to add it as context for AI analysis!
+                            </div>
+                        </div>
+                    </div>
+                    <!-- TUI Panel (Host Terminal) -->
+                    <div id="ai-tui-panel" style="display: none; flex: 1; min-height: 0; background: #1a1b26; position: relative; overflow: hidden;">
+                        <div id="ai-tui-container" style="width: 100%; height: 100%;"></div>
+                        <div id="ai-tui-overlay" style="position: absolute; top: 0; left: 0; right: 0; bottom: 0; background: rgba(0,0,0,0.5); display: flex; align-items: center; justify-content: center; z-index: 10; display: none;">
+                            <div style="background: var(--bg-primary); padding: 12px 20px; border-radius: 8px; border: 1px solid var(--border-color);">
+                                <span id="ai-tui-status">Connecting...</span>
                             </div>
                         </div>
                     </div>

--- a/pkg/web/static/js/app.js
+++ b/pkg/web/static/js/app.js
@@ -6943,3 +6943,190 @@ async function runAutoTroubleshoot() {
         sendMessage();
     }
 }
+
+// ==========================================
+// TUI Mode (Local Host Shell)
+// ==========================================
+let currentTuiTerminal = null;
+let currentTuiWs = null;
+let tuiFitAddon = null;
+let currentAIMode = 'chat'; // 'chat' or 'tui'
+
+function setAIMode(mode) {
+    if (currentAIMode === mode) return;
+    currentAIMode = mode;
+
+    const chatBtn = document.getElementById('ai-btn-chat');
+    const tuiBtn = document.getElementById('ai-btn-tui');
+    const aiMessages = document.getElementById('ai-messages');
+    const tuiPanel = document.getElementById('ai-tui-panel');
+    const inputContainer = document.getElementById('ai-input-container');
+    const contextChips = document.getElementById('context-chips');
+    const guardrails = document.getElementById('guardrails-status');
+
+    if (mode === 'tui') {
+        chatBtn.classList.remove('active');
+        tuiBtn.classList.add('active');
+        aiMessages.style.display = 'none';
+        tuiPanel.style.display = 'flex';
+        if (inputContainer) {
+            inputContainer.style.visibility = 'hidden';
+            inputContainer.style.height = '0';
+            inputContainer.style.padding = '0';
+            inputContainer.style.margin = '0';
+        }
+        if (contextChips) contextChips.style.display = 'none';
+        if (guardrails) guardrails.style.display = 'none';
+        initTuiTerminal();
+    } else {
+        chatBtn.classList.add('active');
+        tuiBtn.classList.remove('active');
+        aiMessages.style.display = 'block';
+        tuiPanel.style.display = 'none';
+        if (inputContainer) {
+            inputContainer.style.visibility = 'visible';
+            inputContainer.style.height = '';
+            inputContainer.style.padding = '';
+            inputContainer.style.margin = '';
+        }
+        if (contextChips) contextChips.style.display = 'flex';
+        if (guardrails) guardrails.style.display = 'flex';
+        closeTuiTerminal();
+    }
+}
+
+function initTuiTerminal() {
+    if (currentTuiTerminal) return;
+
+    const container = document.getElementById('ai-tui-container');
+    if (!container) return;
+    container.innerHTML = '';
+
+    // Standard k13d terminal theme
+    const theme = {
+        background: '#1a1b26',
+        foreground: '#c0caf5',
+        cursor: '#c0caf5',
+        selection: '#33467c',
+        black: '#15161e',
+        red: '#f7768e',
+        green: '#9ece6a',
+        yellow: '#e0af68',
+        blue: '#7aa2f7',
+        magenta: '#bb9af7',
+        cyan: '#7dcfff',
+        white: '#a9b1d6'
+    };
+
+    if (typeof Terminal === 'undefined') {
+        console.error('xterm.js (Terminal) not loaded');
+        return;
+    }
+
+    currentTuiTerminal = new Terminal({
+        cursorBlink: true,
+        fontSize: 12,
+        fontFamily: "'SF Mono', 'Monaco', 'Menlo', monospace",
+        theme: theme
+    });
+
+    if (typeof FitAddon !== 'undefined') {
+        tuiFitAddon = new FitAddon.FitAddon();
+        currentTuiTerminal.loadAddon(tuiFitAddon);
+    }
+
+    if (typeof WebLinksAddon !== 'undefined') {
+        currentTuiTerminal.loadAddon(new WebLinksAddon.WebLinksAddon());
+    }
+
+    currentTuiTerminal.open(container);
+    if (tuiFitAddon) {
+        setTimeout(() => tuiFitAddon.fit(), 100);
+    }
+
+    connectTuiWs();
+}
+
+function connectTuiWs() {
+    if (currentTuiWs) {
+        currentTuiWs.onclose = null;
+        currentTuiWs.close();
+    }
+
+    const overlay = document.getElementById('ai-tui-overlay');
+    const status = document.getElementById('ai-tui-status');
+    if (overlay) overlay.style.display = 'flex';
+    if (status) status.textContent = 'Connecting to host shell...';
+
+    const wsProtocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+    // Use token if available
+    const token = (typeof authToken !== 'undefined') ? authToken : localStorage.getItem('k13d-token');
+    const wsQuery = (token && token !== 'anonymous') ? '?token=' + encodeURIComponent(token) : '';
+    const wsUrl = `${wsProtocol}//${window.location.host}/api/tui/shell${wsQuery}`;
+
+    currentTuiWs = new WebSocket(wsUrl);
+
+    currentTuiWs.onopen = () => {
+        if (overlay) overlay.style.display = 'none';
+        currentTuiTerminal.writeln('\x1b[32m● Host terminal connected\x1b[0m');
+        
+        if (tuiFitAddon) {
+            const dims = tuiFitAddon.proposeDimensions();
+            if (dims) {
+                currentTuiWs.send(JSON.stringify({ type: 'resize', cols: dims.cols, rows: dims.rows }));
+            }
+        }
+    };
+
+    currentTuiWs.onmessage = (event) => {
+        try {
+            const msg = JSON.parse(event.data);
+            if (msg.type === 'output') {
+                currentTuiTerminal.write(msg.data);
+            } else if (msg.type === 'error') {
+                currentTuiTerminal.writeln('\x1b[31mError: ' + msg.data + '\x1b[0m');
+            }
+        } catch (e) {
+            currentTuiTerminal.write(event.data);
+        }
+    };
+
+    currentTuiWs.onclose = () => {
+        if (currentAIMode === 'tui') {
+            if (overlay) overlay.style.display = 'flex';
+            if (status) status.textContent = 'Connection closed. Reconnect in 2s...';
+            setTimeout(connectTuiWs, 2000);
+        }
+    };
+
+    currentTuiTerminal.onData((data) => {
+        if (currentTuiWs && currentTuiWs.readyState === WebSocket.OPEN) {
+            currentTuiWs.send(JSON.stringify({ type: 'input', data: data }));
+        }
+    });
+
+    window.addEventListener('resize', handleTuiResize);
+}
+
+function handleTuiResize() {
+    if (tuiFitAddon && currentTuiTerminal) {
+        tuiFitAddon.fit();
+        const dims = tuiFitAddon.proposeDimensions();
+        if (dims && currentTuiWs && currentTuiWs.readyState === WebSocket.OPEN) {
+            currentTuiWs.send(JSON.stringify({ type: 'resize', cols: dims.cols, rows: dims.rows }));
+        }
+    }
+}
+
+function closeTuiTerminal() {
+    if (currentTuiWs) {
+        currentTuiWs.onclose = null;
+        currentTuiWs.close();
+        currentTuiWs = null;
+    }
+    if (currentTuiTerminal) {
+        currentTuiTerminal.dispose();
+        currentTuiTerminal = null;
+    }
+    window.removeEventListener('resize', handleTuiResize);
+}

--- a/pkg/web/tui_shell_handler.go
+++ b/pkg/web/tui_shell_handler.go
@@ -1,0 +1,107 @@
+package web
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"sync"
+
+	"github.com/creack/pty"
+	"github.com/gorilla/websocket"
+)
+
+// HandleTUIShell handles a WebSocket connection that provides a local shell on the host.
+// This is used for the "TUI Mode" in the AI panel.
+func (s *Server) HandleTUIShell(w http.ResponseWriter, r *http.Request) {
+	// Upgrade to WebSocket
+	conn, err := upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		return
+	}
+	defer conn.Close()
+
+	// Choose shell
+	shell := os.Getenv("SHELL")
+	if shell == "" {
+		shell = "/bin/bash"
+		if _, err := os.Stat(shell); err != nil {
+			shell = "/bin/sh"
+		}
+	}
+
+	// Create command
+	cmd := exec.Command(shell)
+	cmd.Env = append(os.Environ(), "TERM=xterm-256color")
+
+	// Start the command with a pty
+	f, err := pty.Start(cmd)
+	if err != nil {
+		_ = conn.WriteMessage(websocket.TextMessage, []byte(fmt.Sprintf("\r\nFailed to start shell: %v\r\n", err)))
+		return
+	}
+	defer func() {
+		_ = f.Close()
+		_ = cmd.Process.Kill()
+	}()
+
+	var mu sync.Mutex
+	writeMsg := func(msgType string, data string) error {
+		mu.Lock()
+		defer mu.Unlock()
+		m := TerminalMessage{
+			Type: msgType,
+			Data: data,
+		}
+		b, err := json.Marshal(m)
+		if err != nil {
+			return err
+		}
+		return conn.WriteMessage(websocket.TextMessage, b)
+	}
+
+	// Read from PTY and send to WebSocket
+	go func() {
+		buf := make([]byte, 1024)
+		for {
+			n, err := f.Read(buf)
+			if n > 0 {
+				if err := writeMsg("output", string(buf[:n])); err != nil {
+					return
+				}
+			}
+			if err != nil {
+				return
+			}
+		}
+	}()
+
+	// Read from WebSocket and send to PTY
+	for {
+		_, message, err := conn.ReadMessage()
+		if err != nil {
+			break
+		}
+
+		var msg TerminalMessage
+		if err := json.Unmarshal(message, &msg); err != nil {
+			continue
+		}
+
+		switch msg.Type {
+		case "input":
+			if _, err := io.WriteString(f, msg.Data); err != nil {
+				break
+			}
+		case "resize":
+			_ = pty.Setsize(f, &pty.Winsize{
+				Rows: msg.Rows,
+				Cols: msg.Cols,
+			})
+		case "ping":
+			_ = writeMsg("pong", "")
+		}
+	}
+}


### PR DESCRIPTION
## Summary

implement switchable TUI mode for host shell in AI panel

## Changes


AI assistant 패널의 오른쪽 영역에 Terminal 로 전환하는 버튼을 생성

<img width="1496" height="725" alt="Screenshot 2026-04-13 at 3 05 54 PM" src="https://github.com/user-attachments/assets/615b06d8-c669-42a7-88fe-e3b4f4e8815d" />


## Type

<!-- Check the one that applies. -->

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `docs` — Documentation only
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, or dependency update

## Testing

<!-- How did you verify this works? -->

- [ ] `go test -race ./...` passes
- [ ] `golangci-lint run` passes
- [x] Manual TUI / Web UI testing (describe below)

## Checklist

- [ ] Code formatted with `gofmt -s -w .`
- [ ] No new lint warnings
- [ ] Updated docs if needed (README, docs/, CHANGELOG)
- [ ] PR targets `dev` branch (not `main`)
