### PR TITLE
fix(automation): reclaim stale issue worktrees

### DIFF
--- a/pkg/automation/executor.go
+++ b/pkg/automation/executor.go
@@ -55,7 +55,13 @@ func (e *DefaultExecutor) Execute(ctx context.Context, job *Job) (*ExecutionResu
 	branch := buildBranchName(e.cfg.BranchPrefix, job.IssueNumber, job.IssueTitle)
 	worktreePath := filepath.Join(worktreeRoot, fmt.Sprintf("issue-%d-%d", job.IssueNumber, e.now().Unix()))
 	baseRef := e.resolveBaseRef(ctx)
-	if _, err := e.runCommand(ctx, repoPath, []string{"git", "worktree", "add", "--force", "-B", branch, worktreePath, baseRef}, nil); err != nil {
+	if err := e.removeExistingAutomationWorktrees(ctx, repoPath, worktreeRoot, branch, job.IssueNumber); err != nil {
+		return nil, err
+	}
+	if out, err := e.runCommand(ctx, repoPath, []string{"git", "worktree", "add", "--force", "-B", branch, worktreePath, baseRef}, nil); err != nil {
+		if strings.TrimSpace(out) != "" {
+			return nil, fmt.Errorf("create worktree: %w: %s", err, out)
+		}
 		return nil, fmt.Errorf("create worktree: %w", err)
 	}
 
@@ -173,6 +179,94 @@ func (e *DefaultExecutor) DeployPreview(ctx context.Context, job *Job, result *E
 		TargetURL: targetURL,
 		Log:       log,
 	}, nil
+}
+
+type gitWorktreeEntry struct {
+	path   string
+	branch string
+}
+
+func (e *DefaultExecutor) removeExistingAutomationWorktrees(ctx context.Context, repoPath, worktreeRoot, branch string, issueNumber int) error {
+	out, err := e.runCommand(ctx, repoPath, []string{"git", "worktree", "list", "--porcelain"}, nil)
+	if err != nil {
+		return fmt.Errorf("list worktrees: %w", err)
+	}
+
+	expectedBranchRef := "refs/heads/" + branch
+	expectedPrefix := fmt.Sprintf("issue-%d-", issueNumber)
+	for _, entry := range parseGitWorktreeList(out) {
+		if entry.branch != expectedBranchRef && entry.branch != branch {
+			continue
+		}
+		if !strings.HasPrefix(filepath.Base(entry.path), expectedPrefix) {
+			continue
+		}
+		if !isPathWithin(worktreeRoot, entry.path) {
+			continue
+		}
+		if _, err := e.runCommand(ctx, repoPath, []string{"git", "worktree", "remove", "--force", entry.path}, nil); err != nil {
+			return fmt.Errorf("remove stale automation worktree %q: %w", entry.path, err)
+		}
+	}
+	_, _ = e.runCommand(ctx, repoPath, []string{"git", "worktree", "prune"}, nil)
+	return nil
+}
+
+func parseGitWorktreeList(output string) []gitWorktreeEntry {
+	var entries []gitWorktreeEntry
+	current := gitWorktreeEntry{}
+	flush := func() {
+		if current.path == "" {
+			return
+		}
+		entries = append(entries, current)
+		current = gitWorktreeEntry{}
+	}
+
+	for _, line := range strings.Split(output, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			flush()
+			continue
+		}
+		switch {
+		case strings.HasPrefix(line, "worktree "):
+			flush()
+			current.path = strings.TrimSpace(strings.TrimPrefix(line, "worktree "))
+		case strings.HasPrefix(line, "branch "):
+			current.branch = strings.TrimSpace(strings.TrimPrefix(line, "branch "))
+		}
+	}
+	flush()
+	return entries
+}
+
+func isPathWithin(root, path string) bool {
+	rootAbs, err := canonicalPath(root)
+	if err != nil {
+		return false
+	}
+	pathAbs, err := canonicalPath(path)
+	if err != nil {
+		return false
+	}
+	rel, err := filepath.Rel(rootAbs, pathAbs)
+	if err != nil {
+		return false
+	}
+	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) && !filepath.IsAbs(rel))
+}
+
+func canonicalPath(path string) (string, error) {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	resolved, err := filepath.EvalSymlinks(abs)
+	if err == nil {
+		return resolved, nil
+	}
+	return abs, nil
 }
 
 func (e *DefaultExecutor) resolveBaseRef(ctx context.Context) string {

--- a/pkg/automation/executor_test.go
+++ b/pkg/automation/executor_test.go
@@ -1,0 +1,87 @@
+package automation
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/cloudbro-kube-ai/k13d/pkg/config"
+)
+
+func TestDefaultExecutorReclaimsStaleIssueWorktree(t *testing.T) {
+	tmp := t.TempDir()
+	repoPath := filepath.Join(tmp, "repo")
+	worktreeRoot := filepath.Join(tmp, "worktrees")
+	staleWorktreePath := filepath.Join(worktreeRoot, "issue-103-100")
+
+	if err := os.MkdirAll(repoPath, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	runTestCommand(t, repoPath, "git", "init")
+	runTestCommand(t, repoPath, "git", "checkout", "-B", "main")
+	runTestCommand(t, repoPath, "git", "config", "user.email", "k13d@example.invalid")
+	runTestCommand(t, repoPath, "git", "config", "user.name", "k13d test")
+	runTestCommand(t, repoPath, "git", "commit", "--allow-empty", "-m", "initial")
+
+	cfg := config.GitHubAutomationConfig{
+		BaseBranch:         "main",
+		WorktreeRoot:       worktreeRoot,
+		BranchPrefix:       "codex/issue-",
+		DevelopmentCommand: []string{"git", "status", "--short"},
+		CleanupWorktrees:   true,
+	}
+	job := &Job{
+		IssueNumber: 103,
+		IssueTitle:  "Test automation",
+		Repository:  "cloudbro-kube-ai/k13d",
+	}
+	branch := buildBranchName(cfg.BranchPrefix, job.IssueNumber, job.IssueTitle)
+	runTestCommand(t, repoPath, "git", "worktree", "add", "--force", "-B", branch, staleWorktreePath, "main")
+
+	executor := NewDefaultExecutor(cfg, repoPath)
+	executor.now = func() time.Time {
+		return time.Unix(200, 0)
+	}
+	result, err := executor.Execute(context.Background(), job)
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if result.Branch != branch {
+		t.Fatalf("Branch = %q, want %q", result.Branch, branch)
+	}
+	if _, err := os.Stat(staleWorktreePath); !os.IsNotExist(err) {
+		t.Fatalf("stale worktree still exists or stat failed: %v", err)
+	}
+}
+
+func TestParseGitWorktreeList(t *testing.T) {
+	entries := parseGitWorktreeList(`worktree /repo
+HEAD abc123
+branch refs/heads/main
+
+worktree /tmp/worktrees/issue-7-123
+HEAD def456
+branch refs/heads/codex/issue-7-fix
+`)
+	if len(entries) != 2 {
+		t.Fatalf("entries = %#v, want 2 entries", entries)
+	}
+	if entries[1].path != "/tmp/worktrees/issue-7-123" {
+		t.Fatalf("path = %q", entries[1].path)
+	}
+	if entries[1].branch != "refs/heads/codex/issue-7-fix" {
+		t.Fatalf("branch = %q", entries[1].branch)
+	}
+}
+
+func runTestCommand(t *testing.T, dir string, name string, args ...string) {
+	t.Helper()
+	cmd := exec.Command(name, args...)
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("%s %v failed: %v\n%s", name, args, err, string(out))
+	}
+}


### PR DESCRIPTION
## Summary
- Reclaim stale automation-owned worktrees before recreating an issue branch.
- Keep removal scoped to the configured worktree root and matching issue path.
- Add regression coverage for repeated issue automation runs.

## Validation
- go test -count=1 ./pkg/automation
- go build ./cmd/kube-ai-dashboard-cli
- golangci-lint was not available locally; GitHub CI should cover lint.