### PR TITLE
feat(automation): require org members for issue runs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,82 +1,88 @@
-name: Bug Report
-description: Report a bug in k13d
+name: 버그 제보
+description: k13d에서 이상하게 동작하는 부분을 알려주세요.
 labels: ["bug", "triage"]
 body:
   - type: markdown
     attributes:
       value: |
-        Thanks for taking the time to report a bug!
-        Please fill out the sections below so we can reproduce and fix it.
+        제보해주셔서 감사합니다.
+        재현에 필요한 정보만 편하게 적어주세요. 비밀번호, 토큰, kubeconfig, API key 같은 비밀 정보는 넣지 말아주세요.
 
   - type: dropdown
     id: interface
     attributes:
-      label: Interface
-      description: Which interface were you using?
+      label: 어디에서 문제가 보였나요?
+      description: 가장 가까운 항목을 선택해주세요.
       options:
         - TUI (terminal)
         - Web UI
+        - AI Assistant
         - CLI flags / startup
+        - GitHub Issue Automation
+        - Documentation
+        - Other
     validations:
       required: true
 
   - type: textarea
     id: description
     attributes:
-      label: Bug Description
-      description: A clear description of what the bug is.
-      placeholder: When I press 'y' on a Pod, the YAML viewer shows an empty screen...
+      label: 어떤 문제가 있었나요?
+      description: 실제로 보인 현상이나 에러 메시지를 적어주세요.
+      placeholder: 예) TUI에서 Pod 로그를 보다가 Ctrl+C를 누르면 TUI 전체가 종료돼요.
     validations:
       required: true
 
   - type: textarea
     id: steps
     attributes:
-      label: Steps to Reproduce
-      description: Minimal steps to reproduce the behavior.
+      label: 다시 발생시키는 방법
+      description: 가능하면 최소 단계로 적어주세요. 잘 모르겠으면 기억나는 흐름만 적어도 됩니다.
       placeholder: |
-        1. Run `k13d -web -port 8080`
-        2. Navigate to Pods view
-        3. Select a pod and press 'y'
-        4. See empty YAML viewer
+        1. `k13d` 실행
+        2. Pods 화면에서 Pod 선택
+        3. `l` 키로 로그 진입
+        4. Ctrl+C 입력
+        5. TUI가 종료됨
     validations:
       required: true
 
   - type: textarea
     id: expected
     attributes:
-      label: Expected Behavior
-      description: What you expected to happen.
+      label: 기대했던 동작
+      description: 원래는 어떻게 동작해야 한다고 생각했나요?
+      placeholder: 예) 로그 화면만 닫히고 TUI 메인 화면으로 돌아와야 해요.
     validations:
       required: true
 
   - type: textarea
     id: logs
     attributes:
-      label: Logs / Screenshots
-      description: Paste any relevant logs (`k13d --debug`) or screenshots.
+      label: 로그 / 스크린샷
+      description: 관련 로그나 스크린샷이 있으면 붙여주세요. 민감 정보는 지워주세요.
       render: text
 
   - type: input
     id: version
     attributes:
-      label: k13d Version
-      description: Output of `k13d --version` or the Docker image tag.
-      placeholder: v0.9.7
+      label: k13d 버전
+      description: "`k13d --version` 출력이나 Docker image tag를 적어주세요."
+      placeholder: v0.9.9
     validations:
       required: true
 
   - type: input
     id: k8s-version
     attributes:
-      label: Kubernetes Version
-      description: Output of `kubectl version --short`.
+      label: Kubernetes 버전
+      description: 가능하면 `kubectl version --short` 출력을 적어주세요.
       placeholder: v1.31.0
 
   - type: dropdown
     id: os
     attributes:
-      label: OS
+      label: 실행 환경
       options:
         - macOS (arm64)
         - macOS (amd64)
@@ -91,8 +97,8 @@ body:
   - type: dropdown
     id: ai-provider
     attributes:
-      label: AI Provider (if relevant)
-      description: Select if the bug involves the AI assistant.
+      label: AI Provider (AI 관련 문제일 때)
+      description: AI Assistant와 관련된 문제라면 선택해주세요.
       options:
         - N/A
         - OpenAI
@@ -101,4 +107,4 @@ body:
         - Azure OpenAI
         - AWS Bedrock
         - Google Gemini
-        - Embedded LLM (removed)
+        - LiteLLM-compatible provider

--- a/.github/ISSUE_TEMPLATE/codex_task.yml
+++ b/.github/ISSUE_TEMPLATE/codex_task.yml
@@ -1,0 +1,117 @@
+name: Codex 개발 요청
+description: 원하는 변경을 자연어로 적으면, 검토 후 Codex 자동 개발로 이어갈 수 있어요.
+title: "[Codex] "
+labels: ["triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        편하게 적어주세요. 완벽한 요구사항이 아니어도 괜찮습니다.
+
+        이 템플릿은 "이슈 등록 → 검토 → `codex:auto` 라벨 적용 → 자동 개발/PR/리뷰/배포 확인" 흐름에 맞춰져 있습니다.
+        보안을 위해 비밀번호, 토큰, kubeconfig, API key 같은 비밀 정보는 절대 넣지 말아주세요.
+
+  - type: dropdown
+    id: request_type
+    attributes:
+      label: 어떤 요청인가요?
+      description: 가장 가까운 항목을 골라주세요.
+      options:
+        - 버그 수정
+        - 기능 추가
+        - UI/UX 개선
+        - 문서 개선
+        - 리팩토링
+        - 테스트/CI 개선
+        - 잘 모르겠어요
+    validations:
+      required: true
+
+  - type: textarea
+    id: goal
+    attributes:
+      label: 한 줄 목표
+      description: 이 이슈가 해결되면 무엇이 좋아지나요?
+      placeholder: 예) Web UI에서 Job/CronJob 실행 이력을 더 쉽게 확인하고 싶어요.
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: 현재 불편한 점 또는 배경
+      description: 지금 어떤 화면/명령/상황에서 불편한지 알려주세요.
+      placeholder: |
+        예)
+        - Web UI > Workloads > CronJobs에서 다음 실행 시간이 잘 보이지 않아요.
+        - 사용자는 UTC가 아니라 로컬 시간으로 보고 싶어요.
+
+  - type: textarea
+    id: desired_behavior
+    attributes:
+      label: 원하는 동작
+      description: 결과가 어떻게 보이면 좋을지 자연어로 적어주세요.
+      placeholder: |
+        예)
+        - 마지막 실행 시간, 다음 실행 시간, 최근 성공/실패 여부를 한눈에 보고 싶어요.
+        - 시간은 브라우저 로컬 시간으로 표시해주세요.
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: 완료 기준
+      description: Codex와 리뷰어가 "끝났다"고 판단할 수 있는 기준을 적어주세요.
+      placeholder: |
+        예)
+        - CronJob 상세 화면에 최근 실행 Job 목록이 보인다.
+        - 다음 실행 시간이 로컬 시간과 UTC를 함께 보여준다.
+        - 관련 테스트가 추가된다.
+    validations:
+      required: true
+
+  - type: textarea
+    id: validation
+    attributes:
+      label: 확인 방법
+      description: 가능하다면 테스트 명령이나 직접 확인할 화면을 적어주세요.
+      placeholder: |
+        예)
+        - go test ./pkg/web ./pkg/k8s
+        - Web UI에서 CronJob 상세 화면을 열어 확인
+
+  - type: dropdown
+    id: risk
+    attributes:
+      label: 위험도 느낌
+      description: 잘 모르겠으면 "보통"을 선택해도 됩니다.
+      options:
+        - 낮음 - 문서/문구/작은 UI 수정
+        - 보통 - 기능 수정 또는 테스트 추가
+        - 높음 - 인증/권한/배포/데이터 변경
+        - 잘 모르겠어요
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: safety
+    attributes:
+      label: 안전 확인
+      description: 자동 개발로 이어질 수 있으니 아래 내용을 확인해주세요.
+      options:
+        - label: 이 이슈에는 비밀번호, 토큰, kubeconfig, API key 같은 비밀 정보를 넣지 않았습니다.
+          required: true
+        - label: 변경 범위가 너무 크면 작은 이슈로 나눌 수 있다는 점을 이해했습니다.
+          required: true
+
+  - type: markdown
+    attributes:
+      value: |
+        다음 단계:
+
+        1. organization member가 이슈 내용을 확인합니다.
+        2. 자동 개발을 시작해도 괜찮으면 `codex:auto` 라벨을 붙입니다.
+        3. k13d가 같은 이슈 번호의 브랜치와 PR을 만들거나 재사용합니다.
+        4. PR, CI 결과, 배포 확인 링크가 이슈 댓글로 올라옵니다.
+        5. 추가 리뷰가 필요하면 `k13d 코드리뷰 해줘`, 확인 후 병합하려면 `k13d merge 해줘`라고 댓글을 남길 수 있습니다.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: false
 contact_links:
-  - name: Security Vulnerability
+  - name: 보안 취약점 제보
     url: https://github.com/cloudbro-kube-ai/k13d/security/advisories/new
-    about: Report security vulnerabilities privately via GitHub Security Advisories.
-  - name: Questions & Discussions
+    about: 공개 이슈에 올리면 안 되는 보안 취약점은 GitHub Security Advisory로 비공개 제보해주세요.
+  - name: 질문 / 토론
     url: https://github.com/cloudbro-kube-ai/k13d/discussions
-    about: Ask questions or start a discussion (not a bug or feature request).
+    about: 버그나 기능 요청이 아닌 질문, 사용법, 아이디어 토론은 Discussions를 이용해주세요.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,21 +1,23 @@
-name: Feature Request
-description: Suggest a new feature or improvement
+name: 기능 제안
+description: k13d에 있으면 좋을 기능이나 개선 아이디어를 알려주세요.
 labels: ["enhancement"]
 body:
   - type: markdown
     attributes:
       value: |
-        Have an idea to make k13d better? We'd love to hear it!
+        아이디어 환영합니다. 완벽한 설계가 아니어도 괜찮아요.
+        사용자가 어떤 상황에서 무엇을 더 쉽게 하고 싶은지만 적어주셔도 충분합니다.
 
   - type: dropdown
     id: area
     attributes:
-      label: Area
-      description: Which part of k13d does this relate to?
+      label: 어느 영역의 개선인가요?
+      description: 가장 가까운 항목을 선택해주세요.
       options:
         - TUI dashboard
         - Web UI
         - AI assistant
+        - GitHub Issue Automation
         - MCP integration
         - Kubernetes operations
         - Configuration / setup
@@ -28,28 +30,33 @@ body:
   - type: textarea
     id: problem
     attributes:
-      label: Problem or Motivation
-      description: What problem does this solve, or what use case does it enable?
-      placeholder: I often need to compare two deployments side-by-side, but currently...
+      label: 불편한 점 또는 배경
+      description: 지금 어떤 점이 아쉽거나 시간이 오래 걸리나요?
+      placeholder: 예) 이슈에 자연어로 요청하면 개발, 리뷰, 배포 확인까지 이어지는 흐름을 더 쉽게 쓰고 싶어요.
     validations:
       required: true
 
   - type: textarea
     id: solution
     attributes:
-      label: Proposed Solution
-      description: Describe what you'd like to see.
+      label: 원하는 모습
+      description: 어떤 UI, 동작, 명령, 문서가 생기면 좋을지 적어주세요.
+      placeholder: |
+        예)
+        - GitHub Issue 작성 폼이 질문 중심으로 안내해준다.
+        - 완료 기준과 확인 방법을 쉽게 적을 수 있다.
+        - 자동 개발 시작 방법을 이슈 안에서 알려준다.
     validations:
       required: true
 
   - type: textarea
     id: alternatives
     attributes:
-      label: Alternatives Considered
-      description: Any other approaches you thought of.
+      label: 생각해본 다른 방법
+      description: 다른 해결 방법이 있다면 적어주세요. 없어도 괜찮습니다.
 
   - type: textarea
     id: context
     attributes:
-      label: Additional Context
-      description: Screenshots, mockups, links, or anything else that helps explain.
+      label: 추가 자료
+      description: 스크린샷, 목업, 링크, 예시 명령 등 설명에 도움이 되는 자료를 붙여주세요.

--- a/README.md
+++ b/README.md
@@ -265,12 +265,14 @@ The AI assistant can:
 k13d can also act as a lightweight GitHub issue autopilot. When GitHub sends an `issues` webhook to the Web server, k13d can:
 
 - gate execution by label, by default `codex:auto`
-- create an isolated git worktree per issue
+- guide humans through a friendly `Codex 개발 요청` Issue Form before automation starts
+- create or reuse one stable issue branch and worktree, for example `codex/issue-123`
 - run your configured development command
 - wait for GitHub checks on the pushed branch
 - optionally run a separate review command
-- auto-commit, auto-push, and create a draft PR
-- deploy a branch preview behind the same domain, for example `/previews/codex-issue-123-fix/`
+- auto-commit, auto-push, and create or reuse exactly one draft PR for that issue branch
+- assign the issue author and request organization members as PR reviewers
+- deploy a branch preview behind the same domain, for example `/previews/codex-issue-123/`
 - post an issue comment and PR review when a GitHub token is configured
 
 This is designed for local or self-hosted operation. If you run k13d directly on a public HTTPS endpoint, GitHub can reach it without extra relay infrastructure:
@@ -288,24 +290,31 @@ github_automation:
   personal_access_token: ${GITHUB_TOKEN}
   allowed_repositories:
     - cloudbro-kube-ai/k13d
+  require_author_org_member: true
+  mention_org_members: true
+  mention_max_members: 20
+  review_language: ko
   trigger_label: codex:auto
   repo_path: /absolute/path/to/k13d
   worktree_root: ~/.cache/k13d/github-automation
   development_command: ./scripts/run-agent-dev.sh
   review_command: ./scripts/run-agent-review.sh
   wait_for_ci: true
+  allow_issue_merge: true
+  merge_method: squash
   auto_deploy_preview: true
   deploy_preview_command: ./scripts/deploy-preview.sh
   preview_url_base: https://fingerscore.net
   preview_path_prefix: /previews
 ```
 
-The development, review, and preview deployment commands are fully configurable so you can wire in Codex, Claude Code, Gemini CLI, or your own wrapper scripts. A local preview command can start the built branch on a localhost port and print `K13D_PREVIEW_TARGET=http://127.0.0.1:<port>`. k13d then exposes it through the main Web server as `https://fingerscore.net/previews/<branch-slug>/`, which keeps preview access on a single public URL.
+The development, review, and preview deployment commands are fully configurable so you can wire in Codex, Claude Code, Gemini CLI, or your own wrapper scripts. The included `scripts/run-agent-review.sh` wrapper runs `codex exec review` and emits a Korean PR review summary. By default, k13d comments and PR reviews in Korean, mentions organization members when a trusted issue is accepted, assigns the issue author, requests organization members as PR reviewers, and includes the branch preview link after deployment succeeds. One issue maps to one stable branch and one open PR, so re-labeling or reopening the issue continues on the same branch. Organization members can comment `k13d 코드리뷰 해줘` on the issue to re-run the configured review command, and if `allow_issue_merge` is enabled they can comment `k13d merge 해줘` to merge the linked PR into the base branch after human preview verification. After a successful issue-requested merge, k13d closes the GitHub issue as completed. k13d never forwards GitHub token env vars to development/review/deploy commands and redacts GitHub token patterns from captured output. A local preview command can start the built branch on a localhost port and print `K13D_PREVIEW_TARGET=http://127.0.0.1:<port>`. k13d then exposes it through the main Web server as `https://fingerscore.net/previews/<branch-slug>/`, which keeps preview access on a single public URL.
 
 For the full config reference, placeholders, environment variables, and webhook flow, see:
 
 - [Configuration Guide](docs-site/docs/getting-started/configuration.md)
 - [Web UI Guide](docs-site/docs/user-guide/web.md)
+- [GitHub Issue Automation Guide](docs-site/docs/user-guide/github-issue-automation.md)
 - [Architecture](docs-site/docs/concepts/architecture.md)
 - [Environment Variables](docs-site/docs/reference/env-vars.md)
 - Scale deployments, restart rollouts

--- a/docs-site/docs/getting-started/configuration.md
+++ b/docs-site/docs/getting-started/configuration.md
@@ -257,6 +257,8 @@ If you expose the Web UI directly on HTTPS, GitHub can call it with a standard w
 https://your-domain.example/api/github/automation/webhook
 ```
 
+Enable both **Issues** and **Issue comments** in the GitHub webhook. `issues` events start development runs, while `issue_comment` events handle natural-language review and merge requests.
+
 Recommended config:
 
 ```yaml
@@ -266,6 +268,10 @@ github_automation:
   personal_access_token: ${GITHUB_TOKEN}
   allowed_repositories:
     - cloudbro-kube-ai/k13d
+  require_author_org_member: true
+  mention_org_members: true
+  mention_max_members: 20
+  review_language: ko
   trigger_label: codex:auto
   base_branch: main
   remote: origin
@@ -284,6 +290,8 @@ github_automation:
   auto_commit: true
   auto_push: true
   auto_create_pr: true
+  allow_issue_merge: true
+  merge_method: squash
   pull_request_draft: true
   cleanup_worktrees: false
   max_concurrent_jobs: 1
@@ -295,8 +303,17 @@ Behavior summary:
 - Default trigger label: `codex:auto`
 - Webhook signature: validated with `X-Hub-Signature-256`
 - Repository gate: matched against `allowed_repositories`
-- Workspace isolation: each issue gets its own git worktree under `worktree_root`
-- PR/reporting: enabled when `personal_access_token` is configured
+- Author gate: `require_author_org_member: true` only runs issues opened by members of the repository owner organization
+- Reviewer notification: `mention_org_members: true` mentions organization members when a trusted issue is accepted
+- Assignment: trusted issues are assigned to the issue author
+- Reviewers: organization members are requested as reviewers on the generated or reused PR
+- Review language: `review_language: ko` makes built-in issue comments and PR review wrappers Korean
+- Codex review: `review_command: ./scripts/run-agent-review.sh` runs `codex exec review` and posts the result as a PR Review
+- Workspace isolation: each issue gets one stable git worktree under `worktree_root`
+- PR/reporting: one issue maps to one stable branch and one open PR when `personal_access_token` is configured
+- Issue review: organization members can comment `k13d 코드리뷰 해줘` on the issue to re-run the configured review command on the linked PR
+- Issue merge: `allow_issue_merge: true` lets trusted organization members comment `k13d merge 해줘` on the issue to merge the linked PR and close the issue as completed
+- Token safety: GitHub token env vars are not forwarded to agent commands, and captured output is redacted
 - CI gate: `wait_for_ci` waits for GitHub check runs on the pushed commit before review/deploy
 - Preview deploy: `deploy_preview_command` can expose branch previews through the same k13d domain
 
@@ -316,6 +333,7 @@ Behavior summary:
 | `{worktree}` | Issue-specific git worktree path |
 | `{branch}` | Generated branch name |
 | `{base_branch}` | Base branch used for the worktree |
+| `{review_language}` | Preferred review language, default `ko` |
 | `{preview_slug}` | URL-safe preview slug, available to `deploy_preview_command` |
 | `{preview_path}` | Preview path such as `/previews/codex-issue-123/` |
 | `{preview_url}` | Full preview URL when `preview_url_base` is configured |
@@ -362,8 +380,18 @@ Operational notes:
 - `development_command` is required when automation is enabled.
 - `repo_path` must point at the local clone that will be used as the source repo.
 - `personal_access_token` is optional for local execution, but required if you want automatic issue comments, draft PR creation, or PR reviews.
+- `require_author_org_member: true` needs either GitHub's `author_association` webhook value to be `OWNER`/`MEMBER` or a token with organization membership read access.
+- `mention_org_members: true` also needs a GitHub token that can list organization members; `mention_max_members` limits mention volume.
+- k13d assigns the issue author to the accepted issue and requests organization members as PR reviewers after the PR is created or reused.
+- Branch names are stable per issue number, for example `codex/issue-123`, so re-running automation for the same issue continues on the same branch and reuses the existing open PR.
+- `scripts/run-agent-review.sh` is the provided Codex review wrapper. It runs `codex exec review`, includes uncommitted changes when reviewing pre-commit automation output, and writes the last Codex message to stdout for PR Review creation.
+- Review commands are handled from `issue_comment` webhooks when the comment includes `k13d` and a review phrase such as `k13d 코드리뷰 해줘`, `k13d 리뷰해줘`, or `k13d review`.
+- `allow_issue_merge` is disabled by default. Enable it only when the token is scoped for the target repository and branch protection still enforces the checks/reviews you want.
+- Merge commands are handled from `issue_comment` webhooks. Supported natural-language examples include `k13d merge 해줘`, `k13d main에 merge 해줘`, and `k13d 병합해줘`. After GitHub accepts the merge, k13d closes the issue with `state_reason: completed`.
+- k13d removes GitHub token-like env vars from `development_command`, `review_command`, and `deploy_preview_command` environments, then redacts GitHub token patterns from captured logs before storing or commenting them.
+- `review_language: ko` is passed to commands as `{review_language}` and `K13D_GHA_REVIEW_LANGUAGE`; include it in your agent prompt if the external review command should also write Korean.
 - `wait_for_ci` also requires `personal_access_token` because k13d reads GitHub check runs through the GitHub API.
-- `deploy_preview_command` should start or update the branch preview and print `K13D_PREVIEW_TARGET=...` if you want k13d to reverse-proxy it.
+- `deploy_preview_command` should start or update the branch preview and print `K13D_PREVIEW_TARGET=...` if you want k13d to reverse-proxy it. When deployment succeeds, the completion comment includes the human verification link such as `https://fingerscore.net/previews/<branch>/`.
 - `cleanup_worktrees: false` is the safer starting point so you can inspect failed jobs.
 - Keep `max_concurrent_jobs` low unless your agent/runtime is known to be stable under parallel worktrees.
 

--- a/docs-site/docs/reference/env-vars.md
+++ b/docs-site/docs/reference/env-vars.md
@@ -44,10 +44,18 @@ Default config paths are:
 | `K13D_GITHUB_AUTOMATION_TOKEN` | GitHub token used for issue comments, PR creation, and PR reviews | none |
 | `K13D_GITHUB_AUTOMATION_REPO_PATH` | Local repository path used as the source worktree repo | none |
 | `K13D_GITHUB_AUTOMATION_TRIGGER_LABEL` | Label that allows an issue webhook to queue a job | `codex:auto` |
+| `K13D_GITHUB_AUTOMATION_REQUIRE_ORG_MEMBER` | Require issue authors to be members of the repository owner organization | `true` |
+| `K13D_GITHUB_AUTOMATION_MENTION_ORG_MEMBERS` | Mention organization members when a trusted issue is accepted | `true` |
+| `K13D_GITHUB_AUTOMATION_MENTION_MAX_MEMBERS` | Maximum organization members to mention in one issue comment | `20` |
+| `K13D_GITHUB_AUTOMATION_REVIEW_LANGUAGE` | Preferred language for built-in issue/PR review comments and command placeholders | `ko` |
+| `K13D_GITHUB_AUTOMATION_ALLOW_ISSUE_MERGE` | Allow trusted issue comments such as `k13d merge 해줘` to merge the linked PR | `false` |
+| `K13D_GITHUB_AUTOMATION_MERGE_METHOD` | GitHub merge method for issue merge commands: `merge`, `squash`, or `rebase` | `squash` |
 | `K13D_GITHUB_AUTOMATION_WAIT_FOR_CI` | Wait for GitHub check runs before review/deploy | `true` |
 | `K13D_GITHUB_AUTOMATION_AUTO_DEPLOY_PREVIEW` | Run the configured preview deployment command after CI succeeds | `false` |
 | `K13D_GITHUB_AUTOMATION_PREVIEW_URL_BASE` | Public base URL used when building preview links | none |
 | `K13D_GITHUB_AUTOMATION_PREVIEW_PATH_PREFIX` | Path prefix for branch previews on the main Web server | `/previews` |
+| `K13D_CODEX_BIN` | Codex executable used by `scripts/run-agent-review.sh` | `codex` |
+| `K13D_CODEX_REVIEW_MODEL` | Optional Codex model override used by `scripts/run-agent-review.sh` | none |
 
 ## Storage
 
@@ -145,6 +153,10 @@ export K13D_GITHUB_AUTOMATION_WEBHOOK_SECRET=replace-me
 export K13D_GITHUB_AUTOMATION_TOKEN=ghp_xxx
 export K13D_GITHUB_AUTOMATION_REPO_PATH=/absolute/path/to/repo
 export K13D_GITHUB_AUTOMATION_TRIGGER_LABEL=codex:auto
+export K13D_GITHUB_AUTOMATION_REQUIRE_ORG_MEMBER=true
+export K13D_GITHUB_AUTOMATION_MENTION_ORG_MEMBERS=true
+export K13D_GITHUB_AUTOMATION_MENTION_MAX_MEMBERS=20
+export K13D_GITHUB_AUTOMATION_REVIEW_LANGUAGE=ko
 export K13D_GITHUB_AUTOMATION_WAIT_FOR_CI=true
 export K13D_GITHUB_AUTOMATION_AUTO_DEPLOY_PREVIEW=true
 export K13D_GITHUB_AUTOMATION_PREVIEW_URL_BASE=https://fingerscore.net

--- a/docs-site/docs/user-guide/github-issue-automation.md
+++ b/docs-site/docs/user-guide/github-issue-automation.md
@@ -1,0 +1,145 @@
+# GitHub Issue Automation Guide
+
+k13d can turn a labeled GitHub issue into a local development run, commit, push, pull request, CI wait, and optional preview deployment.
+
+This flow is intentionally gated. By default, automation only runs when the issue author is a member of the repository owner organization and the issue has the configured trigger label.
+
+GitHub repository settings still decide who can open an issue. k13d controls whether that issue is allowed to execute the local automation runner.
+
+## Who Can Trigger Automation
+
+- The issue author must be a member of the GitHub organization that owns the repository.
+- The repository must match `github_automation.allowed_repositories`.
+- The issue must have the trigger label, usually `codex:auto`.
+- Review and merge commands are accepted from `issue_comment` webhooks only when the commenter is an organization member.
+- Webhook signatures must pass `X-Hub-Signature-256` verification when a webhook secret is configured.
+
+For organization membership checks, k13d first trusts GitHub webhook `author_association` values of `OWNER` or `MEMBER`. If that value is absent or inconclusive, k13d verifies membership through the GitHub API. Use a token that can read organization membership, for example a fine-grained token with access to the repository and organization metadata, or a classic token with `repo` and `read:org` where appropriate.
+
+When a trusted issue is accepted, k13d can mention organization members in the first automation comment. Built-in issue reviews and PR review wrappers are written in Korean by default. External agent commands also receive `K13D_GHA_REVIEW_LANGUAGE=ko`, so include that variable in your Codex, Claude Code, or Gemini prompt if you want the model-generated review body to stay Korean too.
+
+## Before You Create an Issue
+
+Use automation for small, reviewable changes. A good issue should be scoped enough that the local runner can make one focused PR.
+
+The repository provides friendly GitHub Issue Forms:
+
+- `Codex 개발 요청`: use this when you want issue-driven development automation
+- `버그 제보`: use this when something behaves incorrectly
+- `기능 제안`: use this when you have an improvement idea but do not need automation yet
+
+Include:
+
+- The problem or goal.
+- The expected behavior after the change.
+- Files, pages, commands, or screenshots that give useful context.
+- Validation expectations such as `go test ./pkg/...`, docs build, or Web UI E2E when relevant.
+- Clear constraints, especially when the change must avoid touching CI, deployment, credentials, or public APIs.
+
+Do not include:
+
+- Secrets, kubeconfigs, passwords, API keys, or private tokens.
+- Broad requests such as "refactor everything" without acceptance criteria.
+- Production-destructive instructions.
+
+## Natural Language Issue Template
+
+```markdown
+## Goal
+Describe the user-visible outcome.
+
+## Context
+Explain the current behavior, error, or relevant page/command.
+
+## Requested Change
+- Keep each item small and testable.
+- Mention exact files or screens if known.
+
+## Acceptance Criteria
+- What should be true when the PR is complete?
+- What command or UI flow should pass?
+
+## Validation
+- Suggested tests or checks.
+
+## Safety Notes
+- Anything the runner must not touch.
+```
+
+If you use the `Codex 개발 요청` Issue Form, GitHub asks for the same information with friendlier questions. The form intentionally applies only a triage label. An organization member should review the request first, then add `codex:auto` when it is safe to start automation.
+
+## Trigger Steps
+
+1. Create an issue with the `Codex 개발 요청` form.
+2. Confirm the issue is safe, scoped, and does not contain secrets.
+3. Apply the `codex:auto` label only when you want k13d to execute it.
+4. Confirm k13d assigned the issue author and mentioned the organization reviewers.
+5. Wait for k13d to comment with a result.
+6. Review the linked PR, requested reviewers, CI result, and preview link before merging.
+7. If you want another automated pass, comment `k13d 코드리뷰 해줘` on the issue to run the configured Codex review command again.
+8. If `allow_issue_merge` is enabled, comment `k13d merge 해줘` after approval; k13d merges the PR and closes the issue as completed.
+
+If you need to edit the request, remove `codex:auto`, update the issue, then re-apply the label. k13d uses a stable branch name such as `codex/issue-123`, so the next run continues on the same branch and reuses the existing open PR instead of creating another PR.
+
+## Configuration Example
+
+```yaml
+github_automation:
+  enabled: true
+  webhook_secret: ${K13D_GITHUB_AUTOMATION_WEBHOOK_SECRET}
+  personal_access_token: ${GITHUB_TOKEN}
+  allowed_repositories:
+    - cloudbro-kube-ai/k13d
+  require_author_org_member: true
+  mention_org_members: true
+  mention_max_members: 20
+  review_language: ko
+  trigger_label: codex:auto
+  repo_path: /absolute/path/to/k13d
+  worktree_root: ~/.cache/k13d/github-automation
+  development_command: ./scripts/run-agent-dev.sh
+  review_command: ./scripts/run-agent-review.sh
+  wait_for_ci: true
+  auto_commit: true
+  auto_push: true
+  auto_create_pr: true
+  allow_issue_merge: true
+  merge_method: squash
+  auto_deploy_preview: true
+  deploy_preview_command: ./scripts/deploy-preview.sh
+  preview_url_base: https://fingerscore.net
+  preview_path_prefix: /previews
+```
+
+`require_author_org_member` should stay enabled for public or semi-public repositories. If it is disabled, any user who can create or label issues in an allowed repository can trigger the local automation runner.
+
+`mention_org_members` needs a token that can list organization members. `mention_max_members` caps the number of `@mentions` in one comment so a large organization does not get noisy.
+
+When a trusted issue is accepted, k13d assigns the issue author to the issue. After a PR exists, k13d requests organization members as PR reviewers, capped by `mention_max_members`. This keeps responsibility clear: the author owns the issue, while the organization reviews the generated code.
+
+When `review_command` is set, k13d runs it after development and posts the output as a PR Review. The repository includes `scripts/run-agent-review.sh`, which wraps `codex exec review` and asks Codex to write a Korean review focused on bugs, regressions, security, concurrency, and missing tests. Organization members can also re-run that review from the issue by commenting `k13d 코드리뷰 해줘`, `k13d 리뷰해줘`, or `k13d review`.
+
+If `allow_issue_merge` is enabled, an organization member can complete the flow from the issue by commenting a natural-language merge request such as `k13d merge 해줘`, `k13d main에 merge 해줘`, or `k13d 병합해줘`. k13d finds the stable issue branch PR, asks GitHub to merge it using `merge_method`, closes the issue as completed after a successful merge, and posts a Korean success or failure comment. Branch protection, required reviews, and CI rules still apply on GitHub.
+
+GitHub tokens are kept server-side. k13d does not pass `GITHUB_TOKEN`, `GH_TOKEN`, `K13D_GITHUB_AUTOMATION_TOKEN`, or similar GitHub token env vars to development, review, or preview deployment commands. Captured command output and admin status payloads also redact configured GitHub token and webhook secret values.
+
+When preview deployment is enabled, the deploy command should print `K13D_PREVIEW_TARGET=http://127.0.0.1:<port>` after the branch build is running locally. k13d exposes that branch through `preview_url_base + preview_path_prefix`, for example `https://fingerscore.net/previews/codex-issue-123/`, and includes that human verification link in the final issue comment.
+
+## Troubleshooting
+
+| Symptom | What To Check |
+|---------|---------------|
+| Issue is ignored | Confirm `codex:auto` is present and the author is an organization member |
+| Membership verification fails | Confirm `personal_access_token` can read organization membership |
+| Organization members are not mentioned | Confirm `mention_org_members` is enabled and the token can list org members |
+| Assignee or reviewer request fails | Confirm the token has issue write and pull request write permissions |
+| No PR is created | Confirm `auto_push`, `auto_create_pr`, and `personal_access_token` are configured |
+| Multiple attempts create confusion | Confirm the issue still maps to the stable `codex/issue-<number>` branch and that any older manual PRs use that branch |
+| Review command is ignored | Confirm `review_command` is configured, the comment contains `k13d` and a review phrase, and the commenter is an organization member |
+| Review command fails | Confirm Codex CLI is installed/authenticated on the k13d host and that `scripts/run-agent-review.sh` can run inside the issue worktree |
+| Merge command is ignored | Confirm `allow_issue_merge: true`, the comment contains `k13d` and a merge phrase, and the commenter is an organization member |
+| Merge command fails | Check branch protection, required reviews, CI status, and whether the token has pull request write permissions |
+| PR merged but issue stayed open | Confirm the token has issue write permission; k13d reports this warning in the merge completion comment |
+| No preview link appears | Confirm `auto_deploy_preview` is enabled and `deploy_preview_command` prints `K13D_PREVIEW_TARGET=...` |
+| CI never completes | Check GitHub Actions on the generated branch and `ci_wait_timeout_seconds` |
+| The request is too broad | Split the issue into smaller issues before applying `codex:auto` |

--- a/docs-site/docs/user-guide/web.md
+++ b/docs-site/docs/user-guide/web.md
@@ -256,8 +256,18 @@ There is not yet a dedicated GUI page for automation jobs. Today, the operationa
 
 ### Trigger Rules
 
-- Only GitHub `issues` webhooks are supported right now
+- GitHub `issues` webhooks start automation jobs, and `issue_comment` webhooks handle review/merge commands
 - Default label gate: `codex:auto`
+- The `Codex 개발 요청` GitHub Issue Form collects goal, context, desired behavior, acceptance criteria, validation, and safety confirmation
+- Issue authors must be members of the repository owner organization when `require_author_org_member` is enabled
+- Trusted issues can mention organization members when `mention_org_members` is enabled
+- Trusted issues are assigned to the issue author
+- Generated PRs request organization members as reviewers
+- One issue uses one stable branch, such as `codex/issue-123`, and reuses the existing open PR on later runs
+- If `review_command` is configured, organization members can comment `k13d 코드리뷰 해줘` on the issue to re-run Codex review and post a PR Review
+- If `allow_issue_merge` is enabled, organization members can comment `k13d merge 해줘` on the issue to merge the linked PR and close the issue as completed
+- GitHub token env vars are stripped from automation command environments and redacted from captured output
+- Built-in issue comments and PR review wrappers use Korean by default through `review_language: ko`
 - Supported issue actions: `opened`, `reopened`, `labeled`
 - Webhook signatures are verified with `X-Hub-Signature-256`
 - Repositories can be allow-listed in `config.yaml`
@@ -266,11 +276,13 @@ There is not yet a dedicated GUI page for automation jobs. Today, the operationa
 
 1. Run k13d Web UI on a reachable HTTPS endpoint.
 2. Configure `github_automation` in `config.yaml`.
-3. Add a GitHub webhook for `Issues`.
+3. Add a GitHub webhook for `Issues` and `Issue comments`.
 4. Set the same webhook secret in GitHub and in `config.yaml`.
-5. Label an issue with `codex:auto`.
+5. Create a `Codex 개발 요청` issue, review it, then label it with `codex:auto`.
 
 When the job finishes, k13d can comment back on the issue and create a draft PR if a GitHub token is configured.
+
+For author requirements and a recommended issue template, see the [GitHub Issue Automation Guide](github-issue-automation.md).
 
 ### Branch Preview URLs
 
@@ -286,7 +298,7 @@ The preview deploy command can start each branch on a different local port and p
 K13D_PREVIEW_TARGET=http://127.0.0.1:18123
 ```
 
-k13d stores that target on the automation job and reverse-proxies `/previews/<branch-slug>/...` to it. The browser app also rewrites its own `/api/...` calls under the preview path, so the preview talks to the branch instance rather than the main server.
+k13d stores that target on the automation job and reverse-proxies `/previews/<branch-slug>/...` to it. The browser app also rewrites its own `/api/...` calls under the preview path, so the preview talks to the branch instance rather than the main server. After CI and preview deployment succeed, the issue completion comment includes the preview URL as a human verification link.
 
 ### User Management
 

--- a/docs-site/mkdocs.yml
+++ b/docs-site/mkdocs.yml
@@ -189,6 +189,7 @@ nav:
   - User Guide:
     - TUI Dashboard: user-guide/tui.md
     - Web Dashboard: user-guide/web.md
+    - GitHub Issue Automation: user-guide/github-issue-automation.md
     - Keyboard Shortcuts: user-guide/shortcuts.md
     - Reports: user-guide/reports.md
   - AI & LLM:

--- a/pkg/automation/executor.go
+++ b/pkg/automation/executor.go
@@ -18,6 +18,7 @@ import (
 
 type Executor interface {
 	Execute(ctx context.Context, job *Job) (*ExecutionResult, error)
+	Review(ctx context.Context, job *Job, branch string) (string, error)
 	DeployPreview(ctx context.Context, job *Job, result *ExecutionResult) (*PreviewDeployment, error)
 }
 
@@ -53,9 +54,8 @@ func (e *DefaultExecutor) Execute(ctx context.Context, job *Job) (*ExecutionResu
 	}
 
 	branch := buildBranchName(e.cfg.BranchPrefix, job.IssueNumber, job.IssueTitle)
-	worktreePath := filepath.Join(worktreeRoot, fmt.Sprintf("issue-%d-%d", job.IssueNumber, e.now().Unix()))
-	baseRef := e.resolveBaseRef(ctx)
-	if _, err := e.runCommand(ctx, repoPath, []string{"git", "worktree", "add", "--force", "-B", branch, worktreePath, baseRef}, nil); err != nil {
+	worktreePath := filepath.Join(worktreeRoot, fmt.Sprintf("issue-%d", job.IssueNumber))
+	if err := e.prepareIssueWorktree(ctx, repoPath, worktreePath, branch); err != nil {
 		return nil, fmt.Errorf("create worktree: %w", err)
 	}
 
@@ -65,7 +65,7 @@ func (e *DefaultExecutor) Execute(ctx context.Context, job *Job) (*ExecutionResu
 		}
 	}
 
-	placeholders := jobPlaceholders(job, repoPath, worktreePath, branch, e.cfg.BaseBranch)
+	placeholders := jobPlaceholders(job, repoPath, worktreePath, branch, e.cfg.BaseBranch, e.cfg.ReviewLanguage)
 	devLog, err := e.runCommand(ctx, worktreePath, expandArgs(e.cfg.DevelopmentCommand, placeholders), placeholders)
 	if err != nil {
 		cleanup()
@@ -139,6 +139,49 @@ func (e *DefaultExecutor) Execute(ctx context.Context, job *Job) (*ExecutionResu
 	}, nil
 }
 
+func (e *DefaultExecutor) Review(ctx context.Context, job *Job, branch string) (string, error) {
+	if len(e.cfg.ReviewCommand) == 0 {
+		return "", fmt.Errorf("github automation review_command is not configured")
+	}
+	if job == nil {
+		return "", fmt.Errorf("github automation review requires an issue job")
+	}
+	repoPath := strings.TrimSpace(e.repoPath)
+	if repoPath == "" {
+		return "", fmt.Errorf("github automation repo_path is not configured")
+	}
+	worktreeRoot := strings.TrimSpace(e.cfg.WorktreeRoot)
+	if worktreeRoot == "" {
+		worktreeRoot = config.DefaultGitHubAutomationWorktreeRoot()
+	}
+	if err := os.MkdirAll(worktreeRoot, 0o750); err != nil {
+		return "", err
+	}
+
+	branch = strings.TrimSpace(branch)
+	if branch == "" {
+		branch = buildBranchName(e.cfg.BranchPrefix, job.IssueNumber, job.IssueTitle)
+	}
+	worktreePath := filepath.Join(worktreeRoot, fmt.Sprintf("issue-%d", job.IssueNumber))
+	if err := e.prepareIssueWorktree(ctx, repoPath, worktreePath, branch); err != nil {
+		return "", fmt.Errorf("prepare review worktree: %w", err)
+	}
+
+	cleanup := func() {
+		if e.cfg.CleanupWorktrees {
+			_, _ = e.runCommand(context.Background(), repoPath, []string{"git", "worktree", "remove", "--force", worktreePath}, nil)
+		}
+	}
+
+	placeholders := jobPlaceholders(job, repoPath, worktreePath, branch, e.cfg.BaseBranch, e.cfg.ReviewLanguage)
+	reviewLog, err := e.runCommand(ctx, worktreePath, expandArgs(e.cfg.ReviewCommand, placeholders), placeholders)
+	cleanup()
+	if err != nil {
+		return reviewLog, fmt.Errorf("review command failed: %w", err)
+	}
+	return reviewLog, nil
+}
+
 func (e *DefaultExecutor) DeployPreview(ctx context.Context, job *Job, result *ExecutionResult) (*PreviewDeployment, error) {
 	if !e.cfg.AutoDeployPreview || len(e.cfg.DeployPreviewCommand) == 0 || result == nil {
 		return nil, nil
@@ -151,7 +194,7 @@ func (e *DefaultExecutor) DeployPreview(ctx context.Context, job *Job, result *E
 	slug := buildPreviewSlug(result.Branch)
 	previewPath := previewPathForSlug(e.cfg.PreviewPathPrefix, slug)
 	publicURL := previewPublicURL(e.cfg.PreviewURLBase, previewPath)
-	placeholders := jobPlaceholders(job, e.repoPath, worktreePath, result.Branch, e.cfg.BaseBranch)
+	placeholders := jobPlaceholders(job, e.repoPath, worktreePath, result.Branch, e.cfg.BaseBranch, e.cfg.ReviewLanguage)
 	placeholders["preview_slug"] = slug
 	placeholders["preview_path"] = previewPath
 	placeholders["preview_url"] = publicURL
@@ -196,20 +239,115 @@ func (e *DefaultExecutor) resolveBaseRef(ctx context.Context) string {
 	return "HEAD"
 }
 
+func (e *DefaultExecutor) prepareIssueWorktree(ctx context.Context, repoPath, worktreePath, branch string) error {
+	if isExistingPath(worktreePath) {
+		return e.prepareExistingIssueWorktree(ctx, worktreePath, branch)
+	}
+
+	remote := effectiveRemote(e.cfg.Remote)
+	_, _ = e.runCommand(ctx, repoPath, []string{"git", "fetch", remote, branch}, nil)
+	remoteRef := remote + "/" + branch
+
+	switch {
+	case gitRefExists(ctx, e, repoPath, branch):
+		if _, err := e.runCommand(ctx, repoPath, []string{"git", "worktree", "add", "--force", worktreePath, branch}, nil); err != nil {
+			return err
+		}
+		return e.prepareExistingIssueWorktree(ctx, worktreePath, branch)
+	case gitRefExists(ctx, e, repoPath, remoteRef):
+		if _, err := e.runCommand(ctx, repoPath, []string{"git", "worktree", "add", "--force", "-b", branch, worktreePath, remoteRef}, nil); err != nil {
+			return err
+		}
+		return e.prepareExistingIssueWorktree(ctx, worktreePath, branch)
+	default:
+		baseRef := e.resolveBaseRef(ctx)
+		if _, err := e.runCommand(ctx, repoPath, []string{"git", "worktree", "add", "--force", "-b", branch, worktreePath, baseRef}, nil); err != nil {
+			return err
+		}
+		return e.prepareExistingIssueWorktree(ctx, worktreePath, branch)
+	}
+}
+
+func (e *DefaultExecutor) prepareExistingIssueWorktree(ctx context.Context, worktreePath, branch string) error {
+	if !gitWorktreeExists(ctx, e, worktreePath) {
+		return fmt.Errorf("path %q already exists but is not a git worktree", worktreePath)
+	}
+	statusOut, err := e.runCommand(ctx, worktreePath, []string{"git", "status", "--porcelain"}, nil)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(statusOut) != "" {
+		return fmt.Errorf("issue worktree %q has uncommitted changes; commit, clean, or remove it before retrying", worktreePath)
+	}
+
+	remote := effectiveRemote(e.cfg.Remote)
+	_, _ = e.runCommand(ctx, worktreePath, []string{"git", "fetch", remote, branch}, nil)
+	remoteRef := remote + "/" + branch
+
+	switch {
+	case gitRefExists(ctx, e, worktreePath, branch):
+		if _, err := e.runCommand(ctx, worktreePath, []string{"git", "checkout", branch}, nil); err != nil {
+			return err
+		}
+	case gitRefExists(ctx, e, worktreePath, remoteRef):
+		if _, err := e.runCommand(ctx, worktreePath, []string{"git", "checkout", "-b", branch, remoteRef}, nil); err != nil {
+			return err
+		}
+	default:
+		baseRef := e.resolveBaseRef(ctx)
+		if _, err := e.runCommand(ctx, worktreePath, []string{"git", "checkout", "-b", branch, baseRef}, nil); err != nil {
+			return err
+		}
+	}
+
+	if gitRefExists(ctx, e, worktreePath, remoteRef) {
+		if _, err := e.runCommand(ctx, worktreePath, []string{"git", "pull", "--ff-only", remote, branch}, nil); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func effectiveRemote(remote string) string {
+	remote = strings.TrimSpace(remote)
+	if remote == "" {
+		return "origin"
+	}
+	return remote
+}
+
+func isExistingPath(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}
+
+func gitWorktreeExists(ctx context.Context, e *DefaultExecutor, dir string) bool {
+	_, err := e.runCommand(ctx, dir, []string{"git", "rev-parse", "--is-inside-work-tree"}, nil)
+	return err == nil
+}
+
+func gitRefExists(ctx context.Context, e *DefaultExecutor, dir, ref string) bool {
+	if strings.TrimSpace(ref) == "" {
+		return false
+	}
+	_, err := e.runCommand(ctx, dir, []string{"git", "rev-parse", "--verify", ref}, nil)
+	return err == nil
+}
+
 func (e *DefaultExecutor) runCommand(ctx context.Context, dir string, args []string, placeholders map[string]string) (string, error) {
 	if len(args) == 0 {
 		return "", fmt.Errorf("empty command")
 	}
 	cmd := exec.CommandContext(ctx, args[0], args[1:]...) // #nosec G204 -- commands come from local admin-only github_automation config.
 	cmd.Dir = dir
-	cmd.Env = append(os.Environ(), buildCommandEnv(placeholders)...)
+	cmd.Env = commandEnvironment(placeholders)
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	err := cmd.Run()
 	output := strings.TrimSpace(stdout.String())
 	errOutput := strings.TrimSpace(stderr.String())
-	combined := strings.TrimSpace(strings.Join(compactStrings(output, errOutput), "\n"))
+	combined := RedactGitHubSecrets(strings.TrimSpace(strings.Join(compactStrings(output, errOutput), "\n")), e.cfg)
 	if err != nil {
 		if combined == "" {
 			combined = err.Error()
@@ -237,7 +375,7 @@ func buildCommandEnv(placeholders map[string]string) []string {
 	keys := []string{
 		"issue_number", "issue_title", "issue_body", "issue_url",
 		"issue_author", "repository", "branch", "worktree",
-		"repo_path", "base_branch", "preview_slug", "preview_path", "preview_url",
+		"repo_path", "base_branch", "review_language", "preview_slug", "preview_path", "preview_url",
 	}
 	env := make([]string, 0, len(keys))
 	for _, key := range keys {
@@ -263,18 +401,22 @@ func applyPlaceholders(text string, placeholders map[string]string) string {
 	return text
 }
 
-func jobPlaceholders(job *Job, repoPath, worktreePath, branch, baseBranch string) map[string]string {
+func jobPlaceholders(job *Job, repoPath, worktreePath, branch, baseBranch, reviewLanguage string) map[string]string {
+	if strings.TrimSpace(reviewLanguage) == "" {
+		reviewLanguage = "ko"
+	}
 	return map[string]string{
-		"issue_number": fmt.Sprintf("%d", job.IssueNumber),
-		"issue_title":  job.IssueTitle,
-		"issue_body":   job.IssueBody,
-		"issue_url":    job.IssueURL,
-		"issue_author": job.IssueAuthor,
-		"repository":   job.Repository,
-		"repo_path":    repoPath,
-		"worktree":     worktreePath,
-		"branch":       branch,
-		"base_branch":  baseBranch,
+		"issue_number":    fmt.Sprintf("%d", job.IssueNumber),
+		"issue_title":     job.IssueTitle,
+		"issue_body":      job.IssueBody,
+		"issue_url":       job.IssueURL,
+		"issue_author":    job.IssueAuthor,
+		"repository":      job.Repository,
+		"repo_path":       repoPath,
+		"worktree":        worktreePath,
+		"branch":          branch,
+		"base_branch":     baseBranch,
+		"review_language": reviewLanguage,
 	}
 }
 
@@ -290,16 +432,12 @@ func buildCommitMessage(job *Job) string {
 	return fmt.Sprintf("feat: issue #%d %s", job.IssueNumber, title)
 }
 
-func buildBranchName(prefix string, issueNumber int, title string) string {
+func buildBranchName(prefix string, issueNumber int, _ string) string {
 	prefix = strings.TrimSpace(prefix)
 	if prefix == "" {
 		prefix = "codex/issue-"
 	}
-	slug := sanitizeBranchToken(title)
-	if slug == "" {
-		slug = "work"
-	}
-	branch := fmt.Sprintf("%s%d-%s", prefix, issueNumber, slug)
+	branch := fmt.Sprintf("%s%d", prefix, issueNumber)
 	if len(branch) > 120 {
 		branch = branch[:120]
 	}

--- a/pkg/automation/executor_test.go
+++ b/pkg/automation/executor_test.go
@@ -1,0 +1,49 @@
+package automation
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/cloudbro-kube-ai/k13d/pkg/config"
+)
+
+func TestBuildBranchNameIsStablePerIssue(t *testing.T) {
+	first := buildBranchName("codex/issue-", 123, "first title")
+	second := buildBranchName("codex/issue-", 123, "renamed issue title")
+	if first != "codex/issue-123" {
+		t.Fatalf("branch = %q, want codex/issue-123", first)
+	}
+	if second != first {
+		t.Fatalf("branch changed after title update: %q != %q", second, first)
+	}
+}
+
+func TestFilterAutomationEnvironmentRemovesGitHubTokens(t *testing.T) {
+	env := []string{
+		"GITHUB_TOKEN=ghp_secret",
+		"GH_TOKEN=ghp_secret2",
+		"K13D_GITHUB_AUTOMATION_TOKEN=ghp_secret3",
+		"OPENAI_API_KEY=kept",
+	}
+	got := strings.Join(filterAutomationEnvironment(env), "\n")
+	if strings.Contains(got, "GITHUB_TOKEN") || strings.Contains(got, "GH_TOKEN") || strings.Contains(got, "K13D_GITHUB_AUTOMATION_TOKEN") {
+		t.Fatalf("filtered env leaked github token names: %q", got)
+	}
+	if !strings.Contains(got, "OPENAI_API_KEY=kept") {
+		t.Fatalf("filtered env = %q, want non-github secrets preserved", got)
+	}
+}
+
+func TestRedactGitHubSecrets(t *testing.T) {
+	cfg := config.GitHubAutomationConfig{
+		PersonalAccessToken: "github_pat_abcdefghijklmnopqrstuvwxyz123456",
+		WebhookSecret:       "webhook-secret-value",
+	}
+	got := RedactGitHubSecrets("token=github_pat_abcdefghijklmnopqrstuvwxyz123456 secret=webhook-secret-value", cfg)
+	if strings.Contains(got, "github_pat_") || strings.Contains(got, "webhook-secret-value") {
+		t.Fatalf("redacted text leaked secret: %q", got)
+	}
+	if strings.Count(got, redactedSecret) < 2 {
+		t.Fatalf("redacted text = %q, want redaction markers", got)
+	}
+}

--- a/pkg/automation/github.go
+++ b/pkg/automation/github.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 )
@@ -18,9 +19,16 @@ const githubAPIVersion = "2022-11-28"
 
 type GitHubReporter interface {
 	PostIssueComment(ctx context.Context, repo string, issueNumber int, body string) error
+	AssignIssue(ctx context.Context, repo string, issueNumber int, assignees []string) error
+	FindOpenPullRequestByHead(ctx context.Context, repo, head string) (*PullRequestInfo, error)
 	CreatePullRequest(ctx context.Context, repo, title, head, base, body string, draft bool) (*PullRequestInfo, error)
+	RequestPullRequestReviewers(ctx context.Context, repo string, prNumber int, reviewers []string) error
 	CreatePullRequestReview(ctx context.Context, repo string, prNumber int, body string) error
+	MergePullRequest(ctx context.Context, repo string, prNumber int, method, title, message string) (*PullRequestMergeInfo, error)
+	CloseIssue(ctx context.Context, repo string, issueNumber int, reason string) error
 	WaitForChecks(ctx context.Context, repo, ref string, timeout, interval time.Duration) (*CIResult, error)
+	IsOrganizationMember(ctx context.Context, org, username string) (bool, error)
+	ListOrganizationMembers(ctx context.Context, org string, limit int) ([]string, error)
 }
 
 type GitHubClient struct {
@@ -45,6 +53,41 @@ func (c *GitHubClient) PostIssueComment(ctx context.Context, repo string, issueN
 	return c.post(ctx, fmt.Sprintf("/repos/%s/issues/%d/comments", repo, issueNumber), payload, nil)
 }
 
+func (c *GitHubClient) AssignIssue(ctx context.Context, repo string, issueNumber int, assignees []string) error {
+	assignees = sanitizeGitHubLogins(assignees)
+	if issueNumber <= 0 || len(assignees) == 0 {
+		return nil
+	}
+	payload := map[string][]string{"assignees": assignees}
+	return c.post(ctx, fmt.Sprintf("/repos/%s/issues/%d/assignees", repo, issueNumber), payload, nil)
+}
+
+func (c *GitHubClient) FindOpenPullRequestByHead(ctx context.Context, repo, head string) (*PullRequestInfo, error) {
+	repo = strings.TrimSpace(repo)
+	head = strings.TrimSpace(head)
+	owner := repositoryOwner(repo)
+	if repo == "" || owner == "" || head == "" {
+		return nil, nil
+	}
+
+	query := url.Values{}
+	query.Set("state", "open")
+	query.Set("head", owner+":"+head)
+	query.Set("per_page", "1")
+
+	resp := []struct {
+		Number int    `json:"number"`
+		URL    string `json:"html_url"`
+	}{}
+	if err := c.get(ctx, fmt.Sprintf("/repos/%s/pulls?%s", repo, query.Encode()), &resp); err != nil {
+		return nil, err
+	}
+	if len(resp) == 0 {
+		return nil, nil
+	}
+	return &PullRequestInfo{Number: resp[0].Number, URL: resp[0].URL}, nil
+}
+
 func (c *GitHubClient) CreatePullRequest(ctx context.Context, repo, title, head, base, body string, draft bool) (*PullRequestInfo, error) {
 	resp := struct {
 		Number int    `json:"number"`
@@ -63,6 +106,15 @@ func (c *GitHubClient) CreatePullRequest(ctx context.Context, repo, title, head,
 	return &PullRequestInfo{Number: resp.Number, URL: resp.URL}, nil
 }
 
+func (c *GitHubClient) RequestPullRequestReviewers(ctx context.Context, repo string, prNumber int, reviewers []string) error {
+	reviewers = sanitizeGitHubLogins(reviewers)
+	if prNumber <= 0 || len(reviewers) == 0 {
+		return nil
+	}
+	payload := map[string][]string{"reviewers": reviewers}
+	return c.post(ctx, fmt.Sprintf("/repos/%s/pulls/%d/requested_reviewers", repo, prNumber), payload, nil)
+}
+
 func (c *GitHubClient) CreatePullRequestReview(ctx context.Context, repo string, prNumber int, body string) error {
 	if strings.TrimSpace(body) == "" {
 		return nil
@@ -72,6 +124,154 @@ func (c *GitHubClient) CreatePullRequestReview(ctx context.Context, repo string,
 		"event": "COMMENT",
 	}
 	return c.post(ctx, fmt.Sprintf("/repos/%s/pulls/%d/reviews", repo, prNumber), payload, nil)
+}
+
+func (c *GitHubClient) MergePullRequest(ctx context.Context, repo string, prNumber int, method, title, message string) (*PullRequestMergeInfo, error) {
+	method = normalizeMergeMethod(method)
+	payload := map[string]string{
+		"merge_method": method,
+	}
+	if strings.TrimSpace(title) != "" {
+		payload["commit_title"] = title
+	}
+	if strings.TrimSpace(message) != "" {
+		payload["commit_message"] = message
+	}
+	resp := struct {
+		SHA     string `json:"sha"`
+		Merged  bool   `json:"merged"`
+		Message string `json:"message"`
+	}{}
+	if err := c.put(ctx, fmt.Sprintf("/repos/%s/pulls/%d/merge", repo, prNumber), payload, &resp); err != nil {
+		return nil, err
+	}
+	if !resp.Merged {
+		return &PullRequestMergeInfo{SHA: resp.SHA, Merged: resp.Merged, Message: resp.Message}, fmt.Errorf("github did not merge pull request: %s", strings.TrimSpace(resp.Message))
+	}
+	return &PullRequestMergeInfo{SHA: resp.SHA, Merged: resp.Merged, Message: resp.Message}, nil
+}
+
+func (c *GitHubClient) CloseIssue(ctx context.Context, repo string, issueNumber int, reason string) error {
+	if issueNumber <= 0 {
+		return nil
+	}
+	reason = strings.TrimSpace(reason)
+	if reason == "" {
+		reason = "completed"
+	}
+	payload := map[string]string{
+		"state":        "closed",
+		"state_reason": reason,
+	}
+	return c.patch(ctx, fmt.Sprintf("/repos/%s/issues/%d", repo, issueNumber), payload, nil)
+}
+
+func (c *GitHubClient) IsOrganizationMember(ctx context.Context, org, username string) (bool, error) {
+	org = strings.TrimSpace(org)
+	username = strings.TrimSpace(username)
+	if org == "" || username == "" {
+		return false, nil
+	}
+	if strings.TrimSpace(c.token) == "" {
+		return false, fmt.Errorf("github automation token is not configured")
+	}
+
+	path := fmt.Sprintf("/orgs/%s/members/%s", url.PathEscape(org), url.PathEscape(username))
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+path, nil)
+	if err != nil {
+		return false, err
+	}
+	req.Header.Set("Authorization", "Bearer "+c.token)
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("X-GitHub-Api-Version", githubAPIVersion)
+	req.Header.Set("User-Agent", "k13d-github-automation")
+
+	resp, err := c.httpClient.Do(req) // #nosec G704 -- GitHub API base URL is fixed and request paths are generated internally.
+	if err != nil {
+		return false, err
+	}
+	defer resp.Body.Close()
+
+	switch {
+	case resp.StatusCode == http.StatusNoContent:
+		return true, nil
+	case resp.StatusCode == http.StatusNotFound:
+		return false, nil
+	case resp.StatusCode >= 200 && resp.StatusCode < 300:
+		return true, nil
+	default:
+		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 64<<10))
+		return false, fmt.Errorf("github api %s returned %d: %s", path, resp.StatusCode, strings.TrimSpace(string(respBody)))
+	}
+}
+
+func (c *GitHubClient) ListOrganizationMembers(ctx context.Context, org string, limit int) ([]string, error) {
+	org = strings.TrimSpace(org)
+	if org == "" || limit == 0 {
+		return nil, nil
+	}
+	if limit < 0 {
+		limit = 100
+	}
+	if strings.TrimSpace(c.token) == "" {
+		return nil, fmt.Errorf("github automation token is not configured")
+	}
+
+	type member struct {
+		Login string `json:"login"`
+	}
+	members := make([]string, 0, min(limit, 100))
+	for page := 1; len(members) < limit; page++ {
+		perPage := min(100, limit-len(members))
+		path := fmt.Sprintf("/orgs/%s/members?per_page=%d&page=%d", url.PathEscape(org), perPage, page)
+		var pageMembers []member
+		if err := c.get(ctx, path, &pageMembers); err != nil {
+			return nil, err
+		}
+		if len(pageMembers) == 0 {
+			break
+		}
+		before := len(members)
+		for _, item := range pageMembers {
+			if login := strings.TrimSpace(item.Login); login != "" {
+				members = append(members, login)
+				if len(members) >= limit {
+					break
+				}
+			}
+		}
+		if len(members) == before {
+			break
+		}
+	}
+	return members, nil
+}
+
+func sanitizeGitHubLogins(values []string) []string {
+	out := make([]string, 0, len(values))
+	seen := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		login := strings.TrimSpace(strings.TrimPrefix(value, "@"))
+		if login == "" {
+			continue
+		}
+		key := strings.ToLower(login)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, login)
+	}
+	return out
+}
+
+func normalizeMergeMethod(method string) string {
+	switch strings.ToLower(strings.TrimSpace(method)) {
+	case "merge", "rebase", "squash":
+		return strings.ToLower(strings.TrimSpace(method))
+	default:
+		return "squash"
+	}
 }
 
 func (c *GitHubClient) WaitForChecks(ctx context.Context, repo, ref string, timeout, interval time.Duration) (*CIResult, error) {
@@ -179,6 +379,18 @@ func isSuccessfulCheckConclusion(conclusion string) bool {
 }
 
 func (c *GitHubClient) post(ctx context.Context, path string, payload interface{}, out interface{}) error {
+	return c.doJSON(ctx, http.MethodPost, path, payload, out)
+}
+
+func (c *GitHubClient) put(ctx context.Context, path string, payload interface{}, out interface{}) error {
+	return c.doJSON(ctx, http.MethodPut, path, payload, out)
+}
+
+func (c *GitHubClient) patch(ctx context.Context, path string, payload interface{}, out interface{}) error {
+	return c.doJSON(ctx, http.MethodPatch, path, payload, out)
+}
+
+func (c *GitHubClient) doJSON(ctx context.Context, method, path string, payload interface{}, out interface{}) error {
 	if strings.TrimSpace(c.token) == "" {
 		return fmt.Errorf("github automation token is not configured")
 	}
@@ -188,7 +400,7 @@ func (c *GitHubClient) post(ctx context.Context, path string, payload interface{
 		return err
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+path, bytes.NewReader(body))
+	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, bytes.NewReader(body))
 	if err != nil {
 		return err
 	}
@@ -275,11 +487,12 @@ func ParseIssueEvent(eventName string, body []byte) (*IssueEvent, error) {
 			DefaultBranch string `json:"default_branch"`
 		} `json:"repository"`
 		Issue struct {
-			Number  int    `json:"number"`
-			Title   string `json:"title"`
-			Body    string `json:"body"`
-			HTMLURL string `json:"html_url"`
-			User    struct {
+			Number            int    `json:"number"`
+			Title             string `json:"title"`
+			Body              string `json:"body"`
+			HTMLURL           string `json:"html_url"`
+			AuthorAssociation string `json:"author_association"`
+			User              struct {
 				Login string `json:"login"`
 			} `json:"user"`
 			Labels []struct {
@@ -295,18 +508,80 @@ func ParseIssueEvent(eventName string, body []byte) (*IssueEvent, error) {
 	}
 
 	event := &IssueEvent{
-		EventName:     eventName,
-		Action:        payload.Action,
-		Repository:    payload.Repository.FullName,
-		DefaultBranch: payload.Repository.DefaultBranch,
-		IssueNumber:   payload.Issue.Number,
-		IssueTitle:    payload.Issue.Title,
-		IssueBody:     payload.Issue.Body,
-		IssueURL:      payload.Issue.HTMLURL,
-		IssueAuthor:   payload.Issue.User.Login,
+		EventName:              eventName,
+		Action:                 payload.Action,
+		Repository:             payload.Repository.FullName,
+		DefaultBranch:          payload.Repository.DefaultBranch,
+		IssueNumber:            payload.Issue.Number,
+		IssueTitle:             payload.Issue.Title,
+		IssueBody:              payload.Issue.Body,
+		IssueURL:               payload.Issue.HTMLURL,
+		IssueAuthor:            payload.Issue.User.Login,
+		IssueAuthorAssociation: payload.Issue.AuthorAssociation,
 	}
 	if payload.Label.Name != "" {
 		event.TriggeredLabel = payload.Label.Name
+	}
+	for _, label := range payload.Issue.Labels {
+		event.Labels = append(event.Labels, label.Name)
+	}
+	return event, nil
+}
+
+func ParseIssueCommentEvent(eventName string, body []byte) (*IssueCommentEvent, error) {
+	if eventName != "issue_comment" {
+		return nil, fmt.Errorf("unsupported github event: %s", eventName)
+	}
+
+	var payload struct {
+		Action     string `json:"action"`
+		Repository struct {
+			FullName      string `json:"full_name"`
+			DefaultBranch string `json:"default_branch"`
+		} `json:"repository"`
+		Issue struct {
+			Number            int    `json:"number"`
+			Title             string `json:"title"`
+			Body              string `json:"body"`
+			HTMLURL           string `json:"html_url"`
+			AuthorAssociation string `json:"author_association"`
+			User              struct {
+				Login string `json:"login"`
+			} `json:"user"`
+			Labels []struct {
+				Name string `json:"name"`
+			} `json:"labels"`
+			PullRequest *struct{} `json:"pull_request"`
+		} `json:"issue"`
+		Comment struct {
+			Body              string `json:"body"`
+			AuthorAssociation string `json:"author_association"`
+			User              struct {
+				Login string `json:"login"`
+			} `json:"user"`
+		} `json:"comment"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return nil, err
+	}
+	if payload.Issue.PullRequest != nil {
+		return nil, fmt.Errorf("issue_comment events on pull requests are not supported")
+	}
+
+	event := &IssueCommentEvent{
+		EventName:                eventName,
+		Action:                   payload.Action,
+		Repository:               payload.Repository.FullName,
+		DefaultBranch:            payload.Repository.DefaultBranch,
+		IssueNumber:              payload.Issue.Number,
+		IssueTitle:               payload.Issue.Title,
+		IssueBody:                payload.Issue.Body,
+		IssueURL:                 payload.Issue.HTMLURL,
+		IssueAuthor:              payload.Issue.User.Login,
+		IssueAuthorAssociation:   payload.Issue.AuthorAssociation,
+		CommentBody:              payload.Comment.Body,
+		CommentAuthor:            payload.Comment.User.Login,
+		CommentAuthorAssociation: payload.Comment.AuthorAssociation,
 	}
 	for _, label := range payload.Issue.Labels {
 		event.Labels = append(event.Labels, label.Name)

--- a/pkg/automation/github_test.go
+++ b/pkg/automation/github_test.go
@@ -1,0 +1,275 @@
+package automation
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestGitHubClientIsOrganizationMember(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		want       bool
+		wantErr    bool
+	}{
+		{name: "member", statusCode: http.StatusNoContent, want: true},
+		{name: "not member", statusCode: http.StatusNotFound, want: false},
+		{name: "api error", statusCode: http.StatusForbidden, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != "/orgs/cloudbro-kube-ai/members/alice" {
+					t.Fatalf("unexpected path %q", r.URL.Path)
+				}
+				w.WriteHeader(tt.statusCode)
+			}))
+			defer server.Close()
+
+			client := NewGitHubClient("token")
+			client.baseURL = server.URL
+			got, err := client.IsOrganizationMember(context.Background(), "cloudbro-kube-ai", "alice")
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("IsOrganizationMember() error = %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("IsOrganizationMember() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGitHubClientListOrganizationMembers(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/orgs/cloudbro-kube-ai/members" {
+			t.Fatalf("unexpected path %q", r.URL.Path)
+		}
+		if r.URL.Query().Get("per_page") != "2" {
+			t.Fatalf("per_page = %q, want 2", r.URL.Query().Get("per_page"))
+		}
+		if err := json.NewEncoder(w).Encode([]map[string]string{
+			{"login": "alice"},
+			{"login": "bob"},
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}))
+	defer server.Close()
+
+	client := NewGitHubClient("token")
+	client.baseURL = server.URL
+	got, err := client.ListOrganizationMembers(context.Background(), "cloudbro-kube-ai", 2)
+	if err != nil {
+		t.Fatalf("ListOrganizationMembers() error = %v", err)
+	}
+	want := []string{"alice", "bob"}
+	if len(got) != len(want) {
+		t.Fatalf("members = %#v, want %#v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("members = %#v, want %#v", got, want)
+		}
+	}
+}
+
+func TestGitHubClientAssignIssue(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("method = %s, want POST", r.Method)
+		}
+		if r.URL.Path != "/repos/cloudbro-kube-ai/k13d/issues/7/assignees" {
+			t.Fatalf("unexpected path %q", r.URL.Path)
+		}
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var payload struct {
+			Assignees []string `json:"assignees"`
+		}
+		if err := json.Unmarshal(body, &payload); err != nil {
+			t.Fatal(err)
+		}
+		if len(payload.Assignees) != 1 || payload.Assignees[0] != "alice" {
+			t.Fatalf("assignees = %#v, want alice", payload.Assignees)
+		}
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer server.Close()
+
+	client := NewGitHubClient("token")
+	client.baseURL = server.URL
+	if err := client.AssignIssue(context.Background(), "cloudbro-kube-ai/k13d", 7, []string{"@alice", "alice"}); err != nil {
+		t.Fatalf("AssignIssue() error = %v", err)
+	}
+}
+
+func TestGitHubClientFindOpenPullRequestByHead(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/repos/cloudbro-kube-ai/k13d/pulls" {
+			t.Fatalf("unexpected path %q", r.URL.Path)
+		}
+		if r.URL.Query().Get("state") != "open" {
+			t.Fatalf("state = %q, want open", r.URL.Query().Get("state"))
+		}
+		if r.URL.Query().Get("head") != "cloudbro-kube-ai:codex/issue-7" {
+			t.Fatalf("head = %q", r.URL.Query().Get("head"))
+		}
+		if err := json.NewEncoder(w).Encode([]map[string]interface{}{
+			{"number": 12, "html_url": "https://github.com/cloudbro-kube-ai/k13d/pull/12"},
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}))
+	defer server.Close()
+
+	client := NewGitHubClient("token")
+	client.baseURL = server.URL
+	pr, err := client.FindOpenPullRequestByHead(context.Background(), "cloudbro-kube-ai/k13d", "codex/issue-7")
+	if err != nil {
+		t.Fatalf("FindOpenPullRequestByHead() error = %v", err)
+	}
+	if pr == nil || pr.Number != 12 {
+		t.Fatalf("PR = %#v, want #12", pr)
+	}
+}
+
+func TestGitHubClientRequestPullRequestReviewers(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("method = %s, want POST", r.Method)
+		}
+		if r.URL.Path != "/repos/cloudbro-kube-ai/k13d/pulls/12/requested_reviewers" {
+			t.Fatalf("unexpected path %q", r.URL.Path)
+		}
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var payload struct {
+			Reviewers []string `json:"reviewers"`
+		}
+		if err := json.Unmarshal(body, &payload); err != nil {
+			t.Fatal(err)
+		}
+		if len(payload.Reviewers) != 2 || payload.Reviewers[0] != "alice" || payload.Reviewers[1] != "bob" {
+			t.Fatalf("reviewers = %#v, want alice,bob", payload.Reviewers)
+		}
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer server.Close()
+
+	client := NewGitHubClient("token")
+	client.baseURL = server.URL
+	if err := client.RequestPullRequestReviewers(context.Background(), "cloudbro-kube-ai/k13d", 12, []string{"alice", "@bob", "alice"}); err != nil {
+		t.Fatalf("RequestPullRequestReviewers() error = %v", err)
+	}
+}
+
+func TestGitHubClientMergePullRequest(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut {
+			t.Fatalf("method = %s, want PUT", r.Method)
+		}
+		if r.URL.Path != "/repos/cloudbro-kube-ai/k13d/pulls/12/merge" {
+			t.Fatalf("unexpected path %q", r.URL.Path)
+		}
+		var payload struct {
+			MergeMethod string `json:"merge_method"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatal(err)
+		}
+		if payload.MergeMethod != "squash" {
+			t.Fatalf("merge_method = %q, want squash", payload.MergeMethod)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"sha":     "abc123",
+			"merged":  true,
+			"message": "merged",
+		})
+	}))
+	defer server.Close()
+
+	client := NewGitHubClient("token")
+	client.baseURL = server.URL
+	got, err := client.MergePullRequest(context.Background(), "cloudbro-kube-ai/k13d", 12, "invalid", "title", "message")
+	if err != nil {
+		t.Fatalf("MergePullRequest() error = %v", err)
+	}
+	if got == nil || got.SHA != "abc123" || !got.Merged {
+		t.Fatalf("MergePullRequest() = %#v", got)
+	}
+}
+
+func TestGitHubClientCloseIssue(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPatch {
+			t.Fatalf("method = %s, want PATCH", r.Method)
+		}
+		if r.URL.Path != "/repos/cloudbro-kube-ai/k13d/issues/7" {
+			t.Fatalf("unexpected path %q", r.URL.Path)
+		}
+		var payload struct {
+			State       string `json:"state"`
+			StateReason string `json:"state_reason"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatal(err)
+		}
+		if payload.State != "closed" {
+			t.Fatalf("state = %q, want closed", payload.State)
+		}
+		if payload.StateReason != "completed" {
+			t.Fatalf("state_reason = %q, want completed", payload.StateReason)
+		}
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer server.Close()
+
+	client := NewGitHubClient("token")
+	client.baseURL = server.URL
+	if err := client.CloseIssue(context.Background(), "cloudbro-kube-ai/k13d", 7, ""); err != nil {
+		t.Fatalf("CloseIssue() error = %v", err)
+	}
+}
+
+func TestParseIssueCommentEvent(t *testing.T) {
+	body := []byte(`{
+		"action":"created",
+		"repository":{"full_name":"cloudbro-kube-ai/k13d","default_branch":"main"},
+		"issue":{
+			"number":17,
+			"title":"Automate me",
+			"body":"Please fix this",
+			"html_url":"https://github.com/cloudbro-kube-ai/k13d/issues/17",
+			"author_association":"MEMBER",
+			"user":{"login":"alice"},
+			"labels":[{"name":"codex:auto"}]
+		},
+		"comment":{
+			"body":"k13d merge 해줘",
+			"author_association":"MEMBER",
+			"user":{"login":"bob"}
+		}
+	}`)
+	event, err := ParseIssueCommentEvent("issue_comment", body)
+	if err != nil {
+		t.Fatalf("ParseIssueCommentEvent() error = %v", err)
+	}
+	if event.CommentAuthor != "bob" || event.CommentBody != "k13d merge 해줘" {
+		t.Fatalf("event = %#v", event)
+	}
+}

--- a/pkg/automation/manager.go
+++ b/pkg/automation/manager.go
@@ -126,12 +126,71 @@ func (m *Manager) QueueIssueEvent(event *IssueEvent) QueueResult {
 	m.activeByIssue[key] = job.ID
 	m.mu.Unlock()
 
+	if m.ctx.Err() != nil {
+		m.releaseIssueLock(job)
+		return QueueResult{Ignored: true, Reason: "automation manager is shutting down"}
+	}
+	m.assignIssueAuthor(job)
+	m.postAcceptedIssueComment(job)
+
 	select {
 	case m.queue <- job:
 		return QueueResult{Accepted: true, JobID: job.ID}
 	case <-m.ctx.Done():
 		return QueueResult{Ignored: true, Reason: "automation manager is shutting down"}
 	}
+}
+
+func (m *Manager) HandleIssueCommentEvent(event *IssueCommentEvent) QueueResult {
+	if m == nil || !m.cfg.Enabled {
+		return QueueResult{Ignored: true, Reason: "github automation is disabled"}
+	}
+	if event == nil {
+		return QueueResult{Ignored: true, Reason: "empty event"}
+	}
+	if event.EventName != "issue_comment" {
+		return QueueResult{Ignored: true, Reason: "only issue_comment webhook events are supported"}
+	}
+	if event.Action != "created" {
+		return QueueResult{Ignored: true, Reason: "only new issue comments are supported"}
+	}
+	if event.Repository == "" {
+		return QueueResult{Ignored: true, Reason: "repository is missing from webhook payload"}
+	}
+	if len(m.allowedRepos) > 0 {
+		if _, ok := m.allowedRepos[event.Repository]; !ok {
+			return QueueResult{Ignored: true, Reason: "repository is not in the allowed list"}
+		}
+	}
+	if isReviewCommand(event.CommentBody) {
+		if ok, reason := m.githubUserIsOrgMember(event.Repository, event.CommentAuthor, event.CommentAuthorAssociation); !ok {
+			return QueueResult{Ignored: true, Reason: reason}
+		}
+		if m.reporter == nil {
+			return QueueResult{Ignored: true, Reason: "github token is required to create pull request reviews"}
+		}
+		if len(m.cfg.ReviewCommand) == 0 {
+			return QueueResult{Ignored: true, Reason: "review_command is not configured"}
+		}
+
+		go m.reviewIssuePullRequest(event)
+		return QueueResult{Accepted: true}
+	}
+	if !isMergeCommand(event.CommentBody) {
+		return QueueResult{Ignored: true, Reason: "comment does not contain a k13d review or merge command"}
+	}
+	if !m.cfg.AllowIssueMerge {
+		return QueueResult{Ignored: true, Reason: "issue merge command is disabled"}
+	}
+	if ok, reason := m.githubUserIsOrgMember(event.Repository, event.CommentAuthor, event.CommentAuthorAssociation); !ok {
+		return QueueResult{Ignored: true, Reason: reason}
+	}
+	if m.reporter == nil {
+		return QueueResult{Ignored: true, Reason: "github token is required to merge pull requests"}
+	}
+
+	go m.mergeIssuePullRequest(event)
+	return QueueResult{Accepted: true}
 }
 
 func (m *Manager) ListJobs() []*Job {
@@ -212,15 +271,13 @@ func (m *Manager) runJob(job *Job) {
 	}
 
 	if result != nil && result.HasChanges && m.cfg.AutoPush && m.cfg.AutoCreatePR && m.reporter != nil {
-		title := fmt.Sprintf("Issue #%d: %s", job.IssueNumber, job.IssueTitle)
-		body := buildPullRequestBody(job, result)
-		pr, prErr := m.reporter.CreatePullRequest(m.ctx, job.Repository, title, result.Branch, effectiveBaseBranch(m.cfg), body, m.cfg.PullRequestDraft)
-		if prErr != nil {
+		if prErr := m.ensurePullRequest(job, result); prErr != nil {
 			job.Warnings = append(job.Warnings, "failed to create pull request: "+prErr.Error())
-		} else {
-			job.PullRequestURL = pr.URL
-			job.PullRequestNumber = pr.Number
 		}
+	}
+
+	if job.PullRequestNumber > 0 {
+		m.requestOrganizationReviewers(job)
 	}
 
 	if err := m.waitForCI(job, result); err != nil {
@@ -229,7 +286,7 @@ func (m *Manager) runJob(job *Job) {
 	}
 
 	if result != nil && job.PullRequestNumber > 0 && m.reporter != nil && strings.TrimSpace(result.ReviewLog) != "" {
-		if reviewErr := m.reporter.CreatePullRequestReview(m.ctx, job.Repository, job.PullRequestNumber, buildReviewBody(job, result)); reviewErr != nil {
+		if reviewErr := m.reporter.CreatePullRequestReview(m.ctx, job.Repository, job.PullRequestNumber, buildReviewBody(job, result, m.cfg)); reviewErr != nil {
 			job.Warnings = append(job.Warnings, "failed to create pull request review: "+reviewErr.Error())
 		}
 	}
@@ -370,12 +427,144 @@ func (m *Manager) postCompletionComment(job *Job, result *ExecutionResult, execE
 	if m.reporter == nil {
 		return
 	}
-	body := buildIssueComment(job, result, execErr)
+	body := buildIssueComment(job, result, execErr, m.cfg)
 	if err := m.reporter.PostIssueComment(m.ctx, job.Repository, job.IssueNumber, body); err != nil {
 		m.updateJob(job.ID, func(current *Job) {
 			current.Warnings = append(current.Warnings, "failed to post issue comment: "+err.Error())
 		})
 	}
+}
+
+func (m *Manager) postAcceptedIssueComment(job *Job) {
+	if m.reporter == nil {
+		return
+	}
+	mentions, err := m.organizationMentions(job.Repository)
+	if err != nil {
+		m.updateJob(job.ID, func(current *Job) {
+			current.Warnings = append(current.Warnings, "failed to mention organization members: "+err.Error())
+		})
+	}
+	body := buildAcceptedIssueComment(job, mentions, m.cfg)
+	if err := m.reporter.PostIssueComment(m.ctx, job.Repository, job.IssueNumber, body); err != nil {
+		m.updateJob(job.ID, func(current *Job) {
+			current.Warnings = append(current.Warnings, "failed to post issue acceptance comment: "+err.Error())
+		})
+	}
+}
+
+func (m *Manager) assignIssueAuthor(job *Job) {
+	if m.reporter == nil {
+		return
+	}
+	author := strings.TrimSpace(job.IssueAuthor)
+	if author == "" {
+		return
+	}
+	if err := m.reporter.AssignIssue(m.ctx, job.Repository, job.IssueNumber, []string{author}); err != nil {
+		m.updateJob(job.ID, func(current *Job) {
+			current.Warnings = append(current.Warnings, "failed to assign issue author: "+err.Error())
+		})
+	}
+}
+
+func (m *Manager) ensurePullRequest(job *Job, result *ExecutionResult) error {
+	if result == nil {
+		return nil
+	}
+	title := fmt.Sprintf("Issue #%d: %s", job.IssueNumber, job.IssueTitle)
+	body := buildPullRequestBody(job, result, m.cfg)
+	if existing, err := m.reporter.FindOpenPullRequestByHead(m.ctx, job.Repository, result.Branch); err != nil {
+		return err
+	} else if existing != nil {
+		job.PullRequestURL = existing.URL
+		job.PullRequestNumber = existing.Number
+		return nil
+	}
+
+	pr, err := m.reporter.CreatePullRequest(m.ctx, job.Repository, title, result.Branch, effectiveBaseBranch(m.cfg), body, m.cfg.PullRequestDraft)
+	if err != nil {
+		if existing, findErr := m.reporter.FindOpenPullRequestByHead(m.ctx, job.Repository, result.Branch); findErr == nil && existing != nil {
+			job.PullRequestURL = existing.URL
+			job.PullRequestNumber = existing.Number
+			job.Warnings = append(job.Warnings, "reused existing pull request after create failed: "+err.Error())
+			return nil
+		}
+		return err
+	}
+	job.PullRequestURL = pr.URL
+	job.PullRequestNumber = pr.Number
+	return nil
+}
+
+func (m *Manager) requestOrganizationReviewers(job *Job) {
+	if m.reporter == nil || job.PullRequestNumber <= 0 {
+		return
+	}
+	reviewers, err := m.organizationMembers(job.Repository, m.cfg.MentionMaxMembers)
+	if err != nil {
+		m.updateJob(job.ID, func(current *Job) {
+			current.Warnings = append(current.Warnings, "failed to list organization reviewers: "+err.Error())
+		})
+		return
+	}
+	if len(reviewers) == 0 {
+		return
+	}
+	if err := m.reporter.RequestPullRequestReviewers(m.ctx, job.Repository, job.PullRequestNumber, reviewers); err != nil {
+		m.updateJob(job.ID, func(current *Job) {
+			current.Warnings = append(current.Warnings, "failed to request organization reviewers: "+err.Error())
+		})
+	}
+}
+
+func (m *Manager) organizationMembers(repo string, limit int) ([]string, error) {
+	if m.reporter == nil {
+		return nil, nil
+	}
+	owner := repositoryOwner(repo)
+	if owner == "" {
+		return nil, nil
+	}
+	if limit <= 0 {
+		limit = 20
+	}
+	ctx, cancel := context.WithTimeout(m.ctx, 10*time.Second)
+	defer cancel()
+	members, err := m.reporter.ListOrganizationMembers(ctx, owner, limit)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]string, 0, len(members))
+	seen := make(map[string]struct{}, len(members))
+	for _, member := range members {
+		member = strings.TrimSpace(strings.TrimPrefix(member, "@"))
+		if member == "" {
+			continue
+		}
+		key := strings.ToLower(member)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, member)
+	}
+	return out, nil
+}
+
+func (m *Manager) organizationMentions(repo string) ([]string, error) {
+	if !m.cfg.MentionOrgMembers {
+		return nil, nil
+	}
+	members, err := m.organizationMembers(repo, m.cfg.MentionMaxMembers)
+	if err != nil {
+		return nil, err
+	}
+	mentions := make([]string, 0, len(members))
+	for _, member := range members {
+		mentions = append(mentions, "@"+member)
+	}
+	return mentions, nil
 }
 
 func (m *Manager) updateJob(id string, mutate func(*Job)) {
@@ -400,6 +589,13 @@ func (m *Manager) shouldRun(event *IssueEvent) (bool, string) {
 			return false, "repository is not in the allowed list"
 		}
 	}
+	if ok, reason := m.matchesTrigger(event); !ok {
+		return false, reason
+	}
+	return m.authorCanRun(event)
+}
+
+func (m *Manager) matchesTrigger(event *IssueEvent) (bool, string) {
 	switch event.Action {
 	case "opened", "reopened":
 		if label := strings.TrimSpace(m.cfg.TriggerLabel); label != "" && !containsLabel(event.Labels, label) {
@@ -417,8 +613,132 @@ func (m *Manager) shouldRun(event *IssueEvent) (bool, string) {
 	}
 }
 
+func (m *Manager) authorCanRun(event *IssueEvent) (bool, string) {
+	if !m.cfg.RequireAuthorOrgMember {
+		return true, ""
+	}
+
+	return m.githubUserCanRun(event.Repository, event.IssueAuthor, event.IssueAuthorAssociation)
+}
+
+func (m *Manager) githubUserCanRun(repo, username, association string) (bool, string) {
+	if !m.cfg.RequireAuthorOrgMember {
+		return true, ""
+	}
+	return m.githubUserIsOrgMember(repo, username, association)
+}
+
+func (m *Manager) githubUserIsOrgMember(repo, username, association string) (bool, string) {
+	username = strings.TrimSpace(username)
+	if username == "" {
+		return false, "github user is missing from webhook payload"
+	}
+	owner := repositoryOwner(repo)
+	if owner == "" {
+		return false, "repository owner is missing from webhook payload"
+	}
+
+	switch strings.ToUpper(strings.TrimSpace(association)) {
+	case "OWNER", "MEMBER":
+		return true, ""
+	}
+
+	if m.reporter == nil {
+		return false, fmt.Sprintf("github token is required to verify github user %q is a member of organization %q", username, owner)
+	}
+	ctx, cancel := context.WithTimeout(m.ctx, 10*time.Second)
+	defer cancel()
+	ok, err := m.reporter.IsOrganizationMember(ctx, owner, username)
+	if err != nil {
+		return false, fmt.Sprintf("failed to verify github user organization membership: %v", err)
+	}
+	if !ok {
+		return false, fmt.Sprintf("github user %q is not a member of organization %q", username, owner)
+	}
+	return true, ""
+}
+
+func (m *Manager) mergeIssuePullRequest(event *IssueCommentEvent) {
+	branch := buildBranchName(m.cfg.BranchPrefix, event.IssueNumber, event.IssueTitle)
+	accepted := buildMergeAcceptedComment(event, branch, m.cfg)
+	_ = m.reporter.PostIssueComment(m.ctx, event.Repository, event.IssueNumber, accepted)
+
+	pr, err := m.reporter.FindOpenPullRequestByHead(m.ctx, event.Repository, branch)
+	if err != nil {
+		m.postMergeCompletionComment(event, branch, nil, nil, err, nil)
+		return
+	}
+	if pr == nil {
+		m.postMergeCompletionComment(event, branch, nil, nil, fmt.Errorf("no open pull request found for branch %q", branch), nil)
+		return
+	}
+
+	title := fmt.Sprintf("Merge issue #%d: %s", event.IssueNumber, event.IssueTitle)
+	message := fmt.Sprintf("Merged from issue %s by @%s via k13d issue automation.", event.IssueURL, event.CommentAuthor)
+	merge, err := m.reporter.MergePullRequest(m.ctx, event.Repository, pr.Number, m.cfg.MergeMethod, title, message)
+	var closeErr error
+	if err == nil {
+		closeErr = m.reporter.CloseIssue(m.ctx, event.Repository, event.IssueNumber, "completed")
+	}
+	m.postMergeCompletionComment(event, branch, pr, merge, err, closeErr)
+}
+
+func (m *Manager) reviewIssuePullRequest(event *IssueCommentEvent) {
+	branch := buildBranchName(m.cfg.BranchPrefix, event.IssueNumber, event.IssueTitle)
+	accepted := buildReviewAcceptedComment(event, branch, m.cfg)
+	_ = m.reporter.PostIssueComment(m.ctx, event.Repository, event.IssueNumber, accepted)
+
+	pr, err := m.reporter.FindOpenPullRequestByHead(m.ctx, event.Repository, branch)
+	if err != nil {
+		m.postReviewCompletionComment(event, branch, nil, "", err)
+		return
+	}
+	if pr == nil {
+		m.postReviewCompletionComment(event, branch, nil, "", fmt.Errorf("no open pull request found for branch %q", branch))
+		return
+	}
+
+	job := &Job{
+		Repository:        event.Repository,
+		IssueNumber:       event.IssueNumber,
+		IssueTitle:        event.IssueTitle,
+		IssueBody:         event.IssueBody,
+		IssueURL:          event.IssueURL,
+		IssueAuthor:       event.IssueAuthor,
+		Branch:            branch,
+		PullRequestNumber: pr.Number,
+		PullRequestURL:    pr.URL,
+	}
+	reviewLog, err := m.executor.Review(m.ctx, job, branch)
+	if err == nil {
+		result := &ExecutionResult{Branch: branch, ReviewLog: reviewLog}
+		if reviewErr := m.reporter.CreatePullRequestReview(m.ctx, event.Repository, pr.Number, buildReviewBody(job, result, m.cfg)); reviewErr != nil {
+			err = fmt.Errorf("failed to create pull request review: %w", reviewErr)
+		}
+	}
+	m.postReviewCompletionComment(event, branch, pr, reviewLog, err)
+}
+
+func (m *Manager) postMergeCompletionComment(event *IssueCommentEvent, branch string, pr *PullRequestInfo, merge *PullRequestMergeInfo, err, closeErr error) {
+	body := buildMergeCompletionComment(event, branch, pr, merge, err, closeErr, m.cfg)
+	_ = m.reporter.PostIssueComment(m.ctx, event.Repository, event.IssueNumber, body)
+}
+
+func (m *Manager) postReviewCompletionComment(event *IssueCommentEvent, branch string, pr *PullRequestInfo, reviewLog string, err error) {
+	body := buildReviewCompletionComment(event, branch, pr, reviewLog, err, m.cfg)
+	_ = m.reporter.PostIssueComment(m.ctx, event.Repository, event.IssueNumber, body)
+}
+
 func issueKey(repo string, issueNumber int) string {
 	return fmt.Sprintf("%s#%d", repo, issueNumber)
+}
+
+func repositoryOwner(repo string) string {
+	owner, _, ok := strings.Cut(strings.TrimSpace(repo), "/")
+	if !ok {
+		return ""
+	}
+	return strings.TrimSpace(owner)
 }
 
 func containsLabel(labels []string, want string) bool {
@@ -437,8 +757,180 @@ func effectiveBaseBranch(cfg config.GitHubAutomationConfig) string {
 	return "main"
 }
 
-func buildIssueComment(job *Job, result *ExecutionResult, execErr error) string {
+func buildAcceptedIssueComment(job *Job, mentions []string, cfg config.GitHubAutomationConfig) string {
 	var b strings.Builder
+	if koreanReview(cfg) {
+		fmt.Fprintf(&b, "## k13d 이슈 자동화 접수\n\n")
+		if len(mentions) > 0 {
+			fmt.Fprintf(&b, "%s\n\n", strings.Join(mentions, " "))
+		}
+		fmt.Fprintf(&b, "- 이슈: #%d\n", job.IssueNumber)
+		fmt.Fprintf(&b, "- 작성자: @%s\n", job.IssueAuthor)
+		fmt.Fprintf(&b, "- 상태: 자동화 작업을 큐에 등록했습니다.\n")
+		b.WriteString("- 리뷰 언어: 이슈 검토와 코드 리뷰는 한국어로 진행합니다.\n")
+		b.WriteString("\n작업이 끝나면 PR, CI 결과, 배포 확인 링크가 포함된 완료 코멘트를 남깁니다.\n")
+		return b.String()
+	}
+
+	fmt.Fprintf(&b, "## k13d issue automation accepted\n\n")
+	if len(mentions) > 0 {
+		fmt.Fprintf(&b, "%s\n\n", strings.Join(mentions, " "))
+	}
+	fmt.Fprintf(&b, "- Issue: #%d\n", job.IssueNumber)
+	fmt.Fprintf(&b, "- Author: @%s\n", job.IssueAuthor)
+	fmt.Fprintf(&b, "- Status: queued for automation\n")
+	b.WriteString("\nWhen the job finishes, k13d will comment with the PR, CI result, and preview deployment link.\n")
+	return b.String()
+}
+
+func buildMergeAcceptedComment(event *IssueCommentEvent, branch string, cfg config.GitHubAutomationConfig) string {
+	var b strings.Builder
+	if koreanReview(cfg) {
+		fmt.Fprintf(&b, "## k13d 병합 요청 접수\n\n")
+		fmt.Fprintf(&b, "- 이슈: #%d\n", event.IssueNumber)
+		fmt.Fprintf(&b, "- 요청자: @%s\n", event.CommentAuthor)
+		fmt.Fprintf(&b, "- 대상 브랜치: `%s`\n", branch)
+		fmt.Fprintf(&b, "- 병합 방식: `%s`\n", normalizeMergeMethod(cfg.MergeMethod))
+		b.WriteString("\n연결된 open PR을 찾아 GitHub 병합 API로 처리합니다. 브랜치 보호 규칙이나 CI가 막으면 실패 코멘트를 남깁니다.\n")
+		return b.String()
+	}
+
+	fmt.Fprintf(&b, "## k13d merge request accepted\n\n")
+	fmt.Fprintf(&b, "- Issue: #%d\n", event.IssueNumber)
+	fmt.Fprintf(&b, "- Requested by: @%s\n", event.CommentAuthor)
+	fmt.Fprintf(&b, "- Target branch: `%s`\n", branch)
+	fmt.Fprintf(&b, "- Merge method: `%s`\n", normalizeMergeMethod(cfg.MergeMethod))
+	b.WriteString("\nk13d will find the linked open PR and ask GitHub to merge it. Branch protection or pending CI can still block the merge.\n")
+	return b.String()
+}
+
+func buildReviewAcceptedComment(event *IssueCommentEvent, branch string, cfg config.GitHubAutomationConfig) string {
+	var b strings.Builder
+	if koreanReview(cfg) {
+		fmt.Fprintf(&b, "## k13d 코드 리뷰 요청 접수\n\n")
+		fmt.Fprintf(&b, "- 이슈: #%d\n", event.IssueNumber)
+		fmt.Fprintf(&b, "- 요청자: @%s\n", event.CommentAuthor)
+		fmt.Fprintf(&b, "- 대상 브랜치: `%s`\n", branch)
+		b.WriteString("\n연결된 open PR을 찾아 설정된 `review_command`로 Codex 리뷰를 실행하고 PR Review로 남깁니다.\n")
+		return b.String()
+	}
+
+	fmt.Fprintf(&b, "## k13d code review request accepted\n\n")
+	fmt.Fprintf(&b, "- Issue: #%d\n", event.IssueNumber)
+	fmt.Fprintf(&b, "- Requested by: @%s\n", event.CommentAuthor)
+	fmt.Fprintf(&b, "- Target branch: `%s`\n", branch)
+	b.WriteString("\nk13d will find the linked open PR, run the configured review command, and post a pull request review.\n")
+	return b.String()
+}
+
+func buildMergeCompletionComment(event *IssueCommentEvent, branch string, pr *PullRequestInfo, merge *PullRequestMergeInfo, mergeErr, closeErr error, cfg config.GitHubAutomationConfig) string {
+	var b strings.Builder
+	if koreanReview(cfg) {
+		if mergeErr != nil {
+			fmt.Fprintf(&b, "## k13d 병합 실패\n\n")
+			fmt.Fprintf(&b, "- 이슈: #%d\n", event.IssueNumber)
+			fmt.Fprintf(&b, "- 대상 브랜치: `%s`\n", branch)
+			if pr != nil {
+				fmt.Fprintf(&b, "- Pull Request: %s\n", pr.URL)
+			}
+			fmt.Fprintf(&b, "- 오류: `%s`\n", RedactGitHubSecrets(mergeErr.Error(), cfg))
+			b.WriteString("\nCI 상태, branch protection, reviewer 승인 조건을 확인한 뒤 이슈에 다시 `k13d merge 해줘`라고 남기면 재시도할 수 있습니다.\n")
+			return b.String()
+		}
+		fmt.Fprintf(&b, "## k13d 병합 완료\n\n")
+		fmt.Fprintf(&b, "- 이슈: #%d\n", event.IssueNumber)
+		if pr != nil {
+			fmt.Fprintf(&b, "- Pull Request: %s\n", pr.URL)
+		}
+		if merge != nil && merge.SHA != "" {
+			fmt.Fprintf(&b, "- 병합 커밋: `%s`\n", merge.SHA)
+		}
+		if closeErr != nil {
+			fmt.Fprintf(&b, "\nmain 반영은 완료되었지만 이슈 닫기는 실패했습니다. 오류: `%s`\n", RedactGitHubSecrets(closeErr.Error(), cfg))
+			b.WriteString("권한을 확인한 뒤 필요하면 이슈를 수동으로 닫아주세요.\n")
+			return b.String()
+		}
+		b.WriteString("\nmain 반영이 완료되었고 이슈를 완료 상태로 닫았습니다.\n")
+		return b.String()
+	}
+
+	if mergeErr != nil {
+		fmt.Fprintf(&b, "## k13d merge failed\n\n")
+		fmt.Fprintf(&b, "- Issue: #%d\n", event.IssueNumber)
+		fmt.Fprintf(&b, "- Target branch: `%s`\n", branch)
+		if pr != nil {
+			fmt.Fprintf(&b, "- Pull request: %s\n", pr.URL)
+		}
+		fmt.Fprintf(&b, "- Error: `%s`\n", RedactGitHubSecrets(mergeErr.Error(), cfg))
+		b.WriteString("\nCheck CI, branch protection, and review requirements, then comment `k13d merge` to retry.\n")
+		return b.String()
+	}
+	fmt.Fprintf(&b, "## k13d merge completed\n\n")
+	fmt.Fprintf(&b, "- Issue: #%d\n", event.IssueNumber)
+	if pr != nil {
+		fmt.Fprintf(&b, "- Pull request: %s\n", pr.URL)
+	}
+	if merge != nil && merge.SHA != "" {
+		fmt.Fprintf(&b, "- Merge commit: `%s`\n", merge.SHA)
+	}
+	if closeErr != nil {
+		fmt.Fprintf(&b, "\nMerged into main, but closing the issue failed: `%s`\n", RedactGitHubSecrets(closeErr.Error(), cfg))
+		b.WriteString("Please check token permissions and close the issue manually if needed.\n")
+		return b.String()
+	}
+	b.WriteString("\nMerged into main and closed the issue as completed.\n")
+	return b.String()
+}
+
+func buildReviewCompletionComment(event *IssueCommentEvent, branch string, pr *PullRequestInfo, reviewLog string, reviewErr error, cfg config.GitHubAutomationConfig) string {
+	var b strings.Builder
+	if koreanReview(cfg) {
+		if reviewErr != nil {
+			fmt.Fprintf(&b, "## k13d 코드 리뷰 실패\n\n")
+			fmt.Fprintf(&b, "- 이슈: #%d\n", event.IssueNumber)
+			fmt.Fprintf(&b, "- 대상 브랜치: `%s`\n", branch)
+			if pr != nil {
+				fmt.Fprintf(&b, "- Pull Request: %s\n", pr.URL)
+			}
+			fmt.Fprintf(&b, "- 오류: `%s`\n", RedactGitHubSecrets(reviewErr.Error(), cfg))
+			b.WriteString("\n설정된 `review_command`, Codex 인증 상태, PR 상태를 확인한 뒤 이슈에 다시 `k13d 코드리뷰 해줘`라고 남기면 재시도할 수 있습니다.\n")
+			return b.String()
+		}
+		fmt.Fprintf(&b, "## k13d 코드 리뷰 완료\n\n")
+		fmt.Fprintf(&b, "- 이슈: #%d\n", event.IssueNumber)
+		if pr != nil {
+			fmt.Fprintf(&b, "- Pull Request: %s\n", pr.URL)
+		}
+		if strings.TrimSpace(reviewLog) != "" {
+			b.WriteString("\nPR Review에 Codex 코드 리뷰 결과를 남겼습니다.\n")
+		}
+		return b.String()
+	}
+
+	if reviewErr != nil {
+		fmt.Fprintf(&b, "## k13d code review failed\n\n")
+		fmt.Fprintf(&b, "- Issue: #%d\n", event.IssueNumber)
+		fmt.Fprintf(&b, "- Target branch: `%s`\n", branch)
+		if pr != nil {
+			fmt.Fprintf(&b, "- Pull request: %s\n", pr.URL)
+		}
+		fmt.Fprintf(&b, "- Error: `%s`\n", RedactGitHubSecrets(reviewErr.Error(), cfg))
+		b.WriteString("\nCheck review_command, Codex authentication, and PR state, then comment `k13d review` to retry.\n")
+		return b.String()
+	}
+	fmt.Fprintf(&b, "## k13d code review completed\n\n")
+	fmt.Fprintf(&b, "- Issue: #%d\n", event.IssueNumber)
+	if pr != nil {
+		fmt.Fprintf(&b, "- Pull request: %s\n", pr.URL)
+	}
+	return b.String()
+}
+
+func buildIssueComment(job *Job, result *ExecutionResult, execErr error, cfg config.GitHubAutomationConfig) string {
+	var b strings.Builder
+	if koreanReview(cfg) {
+		return buildKoreanIssueComment(job, result, execErr)
+	}
 	if execErr != nil {
 		fmt.Fprintf(&b, "## k13d issue automation failed\n\n")
 		fmt.Fprintf(&b, "- Issue: #%d\n", job.IssueNumber)
@@ -497,10 +989,89 @@ func buildIssueComment(job *Job, result *ExecutionResult, execErr error) string 
 	return b.String()
 }
 
-func buildPullRequestBody(job *Job, result *ExecutionResult) string {
+func buildKoreanIssueComment(job *Job, result *ExecutionResult, execErr error) string {
 	var b strings.Builder
+	if execErr != nil {
+		fmt.Fprintf(&b, "## k13d 이슈 자동화 실패\n\n")
+		fmt.Fprintf(&b, "- 이슈: #%d\n", job.IssueNumber)
+		fmt.Fprintf(&b, "- 저장소: `%s`\n", job.Repository)
+		fmt.Fprintf(&b, "- 오류: `%s`\n", execErr.Error())
+		if result != nil && strings.TrimSpace(result.DevelopmentLog) != "" {
+			b.WriteString("\n### 개발 명령 출력\n\n```text\n")
+			b.WriteString(result.DevelopmentLog)
+			b.WriteString("\n```\n")
+		}
+		return b.String()
+	}
+
+	fmt.Fprintf(&b, "## k13d 이슈 자동화 완료\n\n")
+	fmt.Fprintf(&b, "- 이슈: #%d\n", job.IssueNumber)
+	fmt.Fprintf(&b, "- 브랜치: `%s`\n", job.Branch)
+	if job.CommitSHA != "" {
+		fmt.Fprintf(&b, "- 커밋: `%s`\n", job.CommitSHA)
+	}
+	if job.PullRequestURL != "" {
+		fmt.Fprintf(&b, "- Pull Request: %s\n", job.PullRequestURL)
+	}
+	if job.CIConclusion != "" {
+		fmt.Fprintf(&b, "- CI 결과: `%s`\n", job.CIConclusion)
+	}
+	if job.CIURL != "" {
+		fmt.Fprintf(&b, "- CI 상세: %s\n", job.CIURL)
+	}
+	if job.PreviewURL != "" {
+		fmt.Fprintf(&b, "- 배포 확인 링크: %s\n", job.PreviewURL)
+	}
+	if !job.HasChanges {
+		b.WriteString("- 결과: 파일 변경이 생성되지 않았습니다.\n")
+	}
+	if strings.TrimSpace(job.DiffStat) != "" {
+		b.WriteString("\n### 변경 요약\n\n```text\n")
+		b.WriteString(job.DiffStat)
+		b.WriteString("\n```\n")
+	}
+	if strings.TrimSpace(job.ReviewLog) != "" {
+		b.WriteString("\n### 코드 리뷰 요약\n\n```text\n")
+		b.WriteString(job.ReviewLog)
+		b.WriteString("\n```\n")
+	}
+	if strings.TrimSpace(job.DeploymentLog) != "" {
+		b.WriteString("\n### 배포 출력\n\n```text\n")
+		b.WriteString(job.DeploymentLog)
+		b.WriteString("\n```\n")
+	}
+	if len(job.Warnings) > 0 {
+		b.WriteString("\n### 경고\n")
+		for _, warning := range job.Warnings {
+			fmt.Fprintf(&b, "- %s\n", warning)
+		}
+	}
+	return b.String()
+}
+
+func buildPullRequestBody(job *Job, result *ExecutionResult, cfg config.GitHubAutomationConfig) string {
+	var b strings.Builder
+	if koreanReview(cfg) {
+		fmt.Fprintf(&b, "## 요약\n")
+		fmt.Fprintf(&b, "- GitHub 이슈 #%d에서 자동 생성된 변경입니다.\n", job.IssueNumber)
+		fmt.Fprintf(&b, "- 연결된 이슈: Closes #%d\n", job.IssueNumber)
+		fmt.Fprintf(&b, "- 원본 이슈: %s\n", job.IssueURL)
+		b.WriteString("- 이슈 검토와 코드 리뷰는 한국어로 진행합니다.\n")
+		if strings.TrimSpace(result.DiffStat) != "" {
+			b.WriteString("\n## 변경 요약\n\n```text\n")
+			b.WriteString(result.DiffStat)
+			b.WriteString("\n```\n")
+		}
+		if strings.TrimSpace(result.ReviewLog) != "" {
+			b.WriteString("\n## 리뷰 메모\n\n```text\n")
+			b.WriteString(result.ReviewLog)
+			b.WriteString("\n```\n")
+		}
+		return b.String()
+	}
 	fmt.Fprintf(&b, "## Summary\n")
 	fmt.Fprintf(&b, "- automated from GitHub issue #%d\n", job.IssueNumber)
+	fmt.Fprintf(&b, "- linked issue: Closes #%d\n", job.IssueNumber)
 	fmt.Fprintf(&b, "- source issue: %s\n", job.IssueURL)
 	if strings.TrimSpace(result.DiffStat) != "" {
 		b.WriteString("\n## Diff Summary\n\n```text\n")
@@ -515,8 +1086,18 @@ func buildPullRequestBody(job *Job, result *ExecutionResult) string {
 	return b.String()
 }
 
-func buildReviewBody(job *Job, result *ExecutionResult) string {
+func buildReviewBody(job *Job, result *ExecutionResult, cfg config.GitHubAutomationConfig) string {
 	var b strings.Builder
+	if koreanReview(cfg) {
+		fmt.Fprintf(&b, "## 자동 코드 리뷰\n\n")
+		fmt.Fprintf(&b, "이 리뷰는 이슈 #%d 자동화 결과에 대해 한국어로 작성되었습니다.\n\n", job.IssueNumber)
+		if strings.TrimSpace(result.ReviewLog) != "" {
+			b.WriteString(result.ReviewLog)
+		} else {
+			b.WriteString("별도의 리뷰 명령이 설정되어 있지 않아 자동 리뷰 요약은 생성되지 않았습니다.")
+		}
+		return b.String()
+	}
 	fmt.Fprintf(&b, "Automated review for issue #%d.\n\n", job.IssueNumber)
 	if strings.TrimSpace(result.ReviewLog) != "" {
 		b.WriteString(result.ReviewLog)
@@ -524,4 +1105,45 @@ func buildReviewBody(job *Job, result *ExecutionResult) string {
 		b.WriteString("No separate review command was configured.")
 	}
 	return b.String()
+}
+
+func koreanReview(cfg config.GitHubAutomationConfig) bool {
+	language := strings.ToLower(strings.TrimSpace(cfg.ReviewLanguage))
+	return language == "" || language == "ko" || strings.HasPrefix(language, "ko-") || strings.Contains(language, "korean")
+}
+
+func isMergeCommand(body string) bool {
+	text := strings.ToLower(strings.TrimSpace(body))
+	if text == "" || !strings.Contains(text, "k13d") {
+		return false
+	}
+	for _, negative := range []string{"don't merge", "do not merge", "not merge", "머지하지", "병합하지"} {
+		if strings.Contains(text, negative) {
+			return false
+		}
+	}
+	for _, positive := range []string{"merge", "머지", "병합", "main에 반영", "main 반영"} {
+		if strings.Contains(text, positive) {
+			return true
+		}
+	}
+	return false
+}
+
+func isReviewCommand(body string) bool {
+	text := strings.ToLower(strings.TrimSpace(body))
+	if text == "" || !strings.Contains(text, "k13d") {
+		return false
+	}
+	for _, negative := range []string{"don't review", "do not review", "not review", "리뷰하지", "검토하지"} {
+		if strings.Contains(text, negative) {
+			return false
+		}
+	}
+	for _, positive := range []string{"review", "code review", "리뷰", "코드리뷰", "검토"} {
+		if strings.Contains(text, positive) {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/automation/manager_test.go
+++ b/pkg/automation/manager_test.go
@@ -5,6 +5,8 @@ import (
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -15,8 +17,10 @@ import (
 type fakeExecutor struct {
 	result       *ExecutionResult
 	deployResult *PreviewDeployment
+	reviewLog    string
 	err          error
 	deployErr    error
+	reviewErr    error
 	block        chan struct{}
 }
 
@@ -27,6 +31,10 @@ func (f *fakeExecutor) Execute(ctx context.Context, job *Job) (*ExecutionResult,
 	return f.result, f.err
 }
 
+func (f *fakeExecutor) Review(ctx context.Context, job *Job, branch string) (string, error) {
+	return f.reviewLog, f.reviewErr
+}
+
 func (f *fakeExecutor) DeployPreview(ctx context.Context, job *Job, result *ExecutionResult) (*PreviewDeployment, error) {
 	return f.deployResult, f.deployErr
 }
@@ -34,9 +42,22 @@ func (f *fakeExecutor) DeployPreview(ctx context.Context, job *Job, result *Exec
 type fakeReporter struct {
 	mu            sync.Mutex
 	issueComments []string
+	assignees     []string
+	reviewers     []string
+	prBody        string
+	reviewBody    string
 	prCreated     bool
 	reviewCreated bool
+	mergedPR      bool
+	issueClosed   bool
+	closeReason   string
+	closeErr      error
+	existingPR    *PullRequestInfo
 	waitedForCI   bool
+	orgMember     bool
+	orgMemberErr  error
+	orgMembers    []string
+	orgMembersErr error
 }
 
 func (f *fakeReporter) PostIssueComment(ctx context.Context, repo string, issueNumber int, body string) error {
@@ -46,18 +67,59 @@ func (f *fakeReporter) PostIssueComment(ctx context.Context, repo string, issueN
 	return nil
 }
 
+func (f *fakeReporter) AssignIssue(ctx context.Context, repo string, issueNumber int, assignees []string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.assignees = append([]string(nil), assignees...)
+	return nil
+}
+
+func (f *fakeReporter) FindOpenPullRequestByHead(ctx context.Context, repo, head string) (*PullRequestInfo, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.existingPR == nil {
+		return nil, nil
+	}
+	pr := *f.existingPR
+	return &pr, nil
+}
+
 func (f *fakeReporter) CreatePullRequest(ctx context.Context, repo, title, head, base, body string, draft bool) (*PullRequestInfo, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.prCreated = true
+	f.prBody = body
 	return &PullRequestInfo{Number: 42, URL: "https://github.com/example/repo/pull/42"}, nil
+}
+
+func (f *fakeReporter) RequestPullRequestReviewers(ctx context.Context, repo string, prNumber int, reviewers []string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.reviewers = append([]string(nil), reviewers...)
+	return nil
 }
 
 func (f *fakeReporter) CreatePullRequestReview(ctx context.Context, repo string, prNumber int, body string) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.reviewCreated = true
+	f.reviewBody = body
 	return nil
+}
+
+func (f *fakeReporter) MergePullRequest(ctx context.Context, repo string, prNumber int, method, title, message string) (*PullRequestMergeInfo, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.mergedPR = true
+	return &PullRequestMergeInfo{SHA: "merge-sha", Merged: true, Message: "merged"}, nil
+}
+
+func (f *fakeReporter) CloseIssue(ctx context.Context, repo string, issueNumber int, reason string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.issueClosed = true
+	f.closeReason = reason
+	return f.closeErr
 }
 
 func (f *fakeReporter) WaitForChecks(ctx context.Context, repo, ref string, timeout, interval time.Duration) (*CIResult, error) {
@@ -67,10 +129,36 @@ func (f *fakeReporter) WaitForChecks(ctx context.Context, repo, ref string, time
 	return &CIResult{Status: "completed", Conclusion: "success", URL: "https://github.com/example/repo/actions/runs/1"}, nil
 }
 
+func (f *fakeReporter) IsOrganizationMember(ctx context.Context, org, username string) (bool, error) {
+	return f.orgMember, f.orgMemberErr
+}
+
+func (f *fakeReporter) ListOrganizationMembers(ctx context.Context, org string, limit int) ([]string, error) {
+	if f.orgMembersErr != nil {
+		return nil, f.orgMembersErr
+	}
+	if len(f.orgMembers) > limit && limit > 0 {
+		return append([]string(nil), f.orgMembers[:limit]...), nil
+	}
+	return append([]string(nil), f.orgMembers...), nil
+}
+
 func (f *fakeReporter) snapshot() (bool, bool, bool, int) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	return f.prCreated, f.reviewCreated, f.waitedForCI, len(f.issueComments)
+}
+
+func (f *fakeReporter) assignedAndReviewers() ([]string, []string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]string(nil), f.assignees...), append([]string(nil), f.reviewers...)
+}
+
+func (f *fakeReporter) mergeSnapshot() (bool, bool, string, []string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.mergedPR, f.issueClosed, f.closeReason, append([]string(nil), f.issueComments...)
 }
 
 func TestVerifyGitHubSignature(t *testing.T) {
@@ -97,6 +185,7 @@ func TestParseIssueEvent(t *testing.T) {
 			"title":"Automate me",
 			"body":"Please fix this",
 			"html_url":"https://github.com/cloudbro-kube-ai/k13d/issues/17",
+			"author_association":"MEMBER",
 			"user":{"login":"alice"},
 			"labels":[{"name":"bug"},{"name":"codex:auto"}]
 		},
@@ -111,6 +200,9 @@ func TestParseIssueEvent(t *testing.T) {
 	}
 	if event.TriggeredLabel != "codex:auto" {
 		t.Fatalf("TriggeredLabel = %s", event.TriggeredLabel)
+	}
+	if event.IssueAuthorAssociation != "MEMBER" {
+		t.Fatalf("IssueAuthorAssociation = %s", event.IssueAuthorAssociation)
 	}
 }
 
@@ -130,14 +222,16 @@ func TestManagerQueueIssueEvent_DedupesActiveIssue(t *testing.T) {
 	manager.reporter = &fakeReporter{}
 
 	event := &IssueEvent{
-		EventName:      "issues",
-		Action:         "opened",
-		Repository:     "cloudbro-kube-ai/k13d",
-		IssueNumber:    99,
-		IssueTitle:     "Automate me",
-		IssueURL:       "https://github.com/cloudbro-kube-ai/k13d/issues/99",
-		Labels:         []string{"codex:auto"},
-		TriggeredLabel: "",
+		EventName:              "issues",
+		Action:                 "opened",
+		Repository:             "cloudbro-kube-ai/k13d",
+		IssueNumber:            99,
+		IssueTitle:             "Automate me",
+		IssueURL:               "https://github.com/cloudbro-kube-ai/k13d/issues/99",
+		IssueAuthor:            "alice",
+		IssueAuthorAssociation: "MEMBER",
+		Labels:                 []string{"codex:auto"},
+		TriggeredLabel:         "",
 	}
 	first := manager.QueueIssueEvent(event)
 	if !first.Accepted {
@@ -166,7 +260,7 @@ func TestManagerRunJob_CreatesPRAndReview(t *testing.T) {
 	}
 	defer manager.Close()
 
-	reporter := &fakeReporter{}
+	reporter := &fakeReporter{orgMembers: []string{"alice", "bob"}}
 	manager.executor = &fakeExecutor{
 		result: &ExecutionResult{
 			Branch:         "codex/issue-101-automate",
@@ -187,13 +281,15 @@ func TestManagerRunJob_CreatesPRAndReview(t *testing.T) {
 	manager.reporter = reporter
 
 	result := manager.QueueIssueEvent(&IssueEvent{
-		EventName:   "issues",
-		Action:      "opened",
-		Repository:  "cloudbro-kube-ai/k13d",
-		IssueNumber: 101,
-		IssueTitle:  "Automate me",
-		IssueURL:    "https://github.com/cloudbro-kube-ai/k13d/issues/101",
-		Labels:      []string{"codex:auto"},
+		EventName:              "issues",
+		Action:                 "opened",
+		Repository:             "cloudbro-kube-ai/k13d",
+		IssueNumber:            101,
+		IssueTitle:             "Automate me",
+		IssueURL:               "https://github.com/cloudbro-kube-ai/k13d/issues/101",
+		IssueAuthor:            "alice",
+		IssueAuthorAssociation: "MEMBER",
+		Labels:                 []string{"codex:auto"},
 	})
 	if !result.Accepted {
 		t.Fatalf("QueueIssueEvent() = %#v", result)
@@ -219,6 +315,25 @@ func TestManagerRunJob_CreatesPRAndReview(t *testing.T) {
 			if issueComments == 0 {
 				t.Fatal("expected issue completion comment")
 			}
+			assignees, reviewers := reporter.assignedAndReviewers()
+			if strings.Join(assignees, ",") != "alice" {
+				t.Fatalf("assignees = %#v, want issue author", assignees)
+			}
+			if strings.Join(reviewers, ",") != "alice,bob" {
+				t.Fatalf("reviewers = %#v, want organization members", reviewers)
+			}
+			if !strings.Contains(reporter.issueComments[0], "@alice @bob") {
+				t.Fatalf("acceptance comment = %q, want org mentions", reporter.issueComments[0])
+			}
+			if !strings.Contains(reporter.issueComments[len(reporter.issueComments)-1], "배포 확인 링크") {
+				t.Fatalf("completion comment = %q, want Korean preview link", reporter.issueComments[len(reporter.issueComments)-1])
+			}
+			if !strings.Contains(reporter.prBody, "## 요약") {
+				t.Fatalf("PR body = %q, want Korean body", reporter.prBody)
+			}
+			if !strings.Contains(reporter.reviewBody, "## 자동 코드 리뷰") {
+				t.Fatalf("review body = %q, want Korean review", reporter.reviewBody)
+			}
 			if job.PreviewURL == "" || job.PreviewTarget == "" {
 				t.Fatalf("expected preview details, got url=%q target=%q", job.PreviewURL, job.PreviewTarget)
 			}
@@ -231,6 +346,325 @@ func TestManagerRunJob_CreatesPRAndReview(t *testing.T) {
 		time.Sleep(10 * time.Millisecond)
 	}
 	t.Fatal("timed out waiting for automation job to finish")
+}
+
+func TestManagerRunJob_ReusesExistingPullRequestForIssueBranch(t *testing.T) {
+	cfg := config.NewDefaultConfig().GitHub
+	cfg.Enabled = true
+	cfg.AllowedRepositories = []string{"cloudbro-kube-ai/k13d"}
+	cfg.TriggerLabel = "codex:auto"
+	cfg.AutoPush = true
+	cfg.AutoCreatePR = true
+
+	manager, err := NewManager(cfg)
+	if err != nil {
+		t.Fatalf("NewManager() error = %v", err)
+	}
+	defer manager.Close()
+
+	reporter := &fakeReporter{
+		existingPR: &PullRequestInfo{Number: 77, URL: "https://github.com/example/repo/pull/77"},
+		orgMembers: []string{"alice", "bob"},
+	}
+	manager.executor = &fakeExecutor{
+		result: &ExecutionResult{
+			Branch:         "codex/issue-104",
+			WorktreePath:   "/tmp/worktree",
+			CommitSHA:      "def456",
+			HasChanges:     true,
+			DevelopmentLog: "continued change",
+		},
+	}
+	manager.reporter = reporter
+
+	result := manager.QueueIssueEvent(&IssueEvent{
+		EventName:              "issues",
+		Action:                 "labeled",
+		Repository:             "cloudbro-kube-ai/k13d",
+		IssueNumber:            104,
+		IssueTitle:             "Keep working here",
+		IssueURL:               "https://github.com/cloudbro-kube-ai/k13d/issues/104",
+		IssueAuthor:            "alice",
+		IssueAuthorAssociation: "MEMBER",
+		Labels:                 []string{"codex:auto"},
+		TriggeredLabel:         "codex:auto",
+	})
+	if !result.Accepted {
+		t.Fatalf("QueueIssueEvent() = %#v", result)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		job, ok := manager.GetJob(result.JobID)
+		if ok && (job.Status == JobStatusSucceeded || job.Status == JobStatusFailed) {
+			if job.Status != JobStatusSucceeded {
+				t.Fatalf("job status = %s, error = %s", job.Status, job.Error)
+			}
+			if reporter.prCreated {
+				t.Fatal("expected existing PR to be reused instead of creating another PR")
+			}
+			if job.PullRequestNumber != 77 || job.PullRequestURL != "https://github.com/example/repo/pull/77" {
+				t.Fatalf("job PR = #%d %q, want existing PR", job.PullRequestNumber, job.PullRequestURL)
+			}
+			_, reviewers := reporter.assignedAndReviewers()
+			if strings.Join(reviewers, ",") != "alice,bob" {
+				t.Fatalf("reviewers = %#v, want organization members", reviewers)
+			}
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("timed out waiting for automation job to finish")
+}
+
+func TestManagerHandleIssueCommentEvent_MergesExistingIssuePR(t *testing.T) {
+	cfg := config.NewDefaultConfig().GitHub
+	cfg.Enabled = true
+	cfg.AllowIssueMerge = true
+	cfg.AllowedRepositories = []string{"cloudbro-kube-ai/k13d"}
+
+	manager, err := NewManager(cfg)
+	if err != nil {
+		t.Fatalf("NewManager() error = %v", err)
+	}
+	defer manager.Close()
+
+	reporter := &fakeReporter{
+		existingPR: &PullRequestInfo{Number: 88, URL: "https://github.com/example/repo/pull/88"},
+	}
+	manager.reporter = reporter
+
+	result := manager.HandleIssueCommentEvent(&IssueCommentEvent{
+		EventName:                "issue_comment",
+		Action:                   "created",
+		Repository:               "cloudbro-kube-ai/k13d",
+		IssueNumber:              105,
+		IssueTitle:               "Ship it",
+		IssueURL:                 "https://github.com/cloudbro-kube-ai/k13d/issues/105",
+		CommentBody:              "k13d main에 merge 해줘",
+		CommentAuthor:            "alice",
+		CommentAuthorAssociation: "MEMBER",
+	})
+	if !result.Accepted {
+		t.Fatalf("HandleIssueCommentEvent() = %#v, want accepted", result)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		merged, issueClosed, closeReason, comments := reporter.mergeSnapshot()
+		if merged && len(comments) >= 2 {
+			if !issueClosed {
+				t.Fatal("expected issue to be closed after successful merge")
+			}
+			if closeReason != "completed" {
+				t.Fatalf("close reason = %q, want completed", closeReason)
+			}
+			if !strings.Contains(comments[len(comments)-1], "병합 완료") {
+				t.Fatalf("completion comment = %q, want Korean merge success", comments[len(comments)-1])
+			}
+			if !strings.Contains(comments[len(comments)-1], "이슈를 완료 상태로 닫았습니다") {
+				t.Fatalf("completion comment = %q, want issue close confirmation", comments[len(comments)-1])
+			}
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("timed out waiting for merge command")
+}
+
+func TestManagerHandleIssueCommentEvent_MergeSuccessReportsCloseFailure(t *testing.T) {
+	cfg := config.NewDefaultConfig().GitHub
+	cfg.Enabled = true
+	cfg.AllowIssueMerge = true
+	cfg.AllowedRepositories = []string{"cloudbro-kube-ai/k13d"}
+
+	manager, err := NewManager(cfg)
+	if err != nil {
+		t.Fatalf("NewManager() error = %v", err)
+	}
+	defer manager.Close()
+
+	reporter := &fakeReporter{
+		closeErr:   errors.New("missing issue write permission"),
+		existingPR: &PullRequestInfo{Number: 88, URL: "https://github.com/example/repo/pull/88"},
+	}
+	manager.reporter = reporter
+
+	result := manager.HandleIssueCommentEvent(&IssueCommentEvent{
+		EventName:                "issue_comment",
+		Action:                   "created",
+		Repository:               "cloudbro-kube-ai/k13d",
+		IssueNumber:              105,
+		IssueTitle:               "Ship it",
+		IssueURL:                 "https://github.com/cloudbro-kube-ai/k13d/issues/105",
+		CommentBody:              "k13d main에 merge 해줘",
+		CommentAuthor:            "alice",
+		CommentAuthorAssociation: "MEMBER",
+	})
+	if !result.Accepted {
+		t.Fatalf("HandleIssueCommentEvent() = %#v, want accepted", result)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		merged, issueClosed, _, comments := reporter.mergeSnapshot()
+		if merged && issueClosed && len(comments) >= 2 {
+			if !strings.Contains(comments[len(comments)-1], "main 반영은 완료되었지만 이슈 닫기는 실패했습니다") {
+				t.Fatalf("completion comment = %q, want close failure warning", comments[len(comments)-1])
+			}
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("timed out waiting for merge command")
+}
+
+func TestManagerHandleIssueCommentEvent_RequiresMergeEnabled(t *testing.T) {
+	cfg := config.NewDefaultConfig().GitHub
+	cfg.Enabled = true
+	cfg.AllowedRepositories = []string{"cloudbro-kube-ai/k13d"}
+
+	manager, err := NewManager(cfg)
+	if err != nil {
+		t.Fatalf("NewManager() error = %v", err)
+	}
+	defer manager.Close()
+	manager.reporter = &fakeReporter{}
+
+	result := manager.HandleIssueCommentEvent(&IssueCommentEvent{
+		EventName:                "issue_comment",
+		Action:                   "created",
+		Repository:               "cloudbro-kube-ai/k13d",
+		IssueNumber:              106,
+		IssueTitle:               "Ship it",
+		CommentBody:              "k13d merge",
+		CommentAuthor:            "alice",
+		CommentAuthorAssociation: "MEMBER",
+	})
+	if !result.Ignored || !strings.Contains(result.Reason, "disabled") {
+		t.Fatalf("HandleIssueCommentEvent() = %#v, want disabled", result)
+	}
+}
+
+func TestManagerHandleIssueCommentEvent_RunsCodexReview(t *testing.T) {
+	cfg := config.NewDefaultConfig().GitHub
+	cfg.Enabled = true
+	cfg.AllowedRepositories = []string{"cloudbro-kube-ai/k13d"}
+	cfg.ReviewCommand = []string{"./scripts/run-agent-review.sh"}
+
+	manager, err := NewManager(cfg)
+	if err != nil {
+		t.Fatalf("NewManager() error = %v", err)
+	}
+	defer manager.Close()
+
+	reporter := &fakeReporter{
+		existingPR: &PullRequestInfo{Number: 89, URL: "https://github.com/example/repo/pull/89"},
+	}
+	manager.executor = &fakeExecutor{reviewLog: "발견사항 없음. 잔여 리스크는 E2E 범위입니다."}
+	manager.reporter = reporter
+
+	result := manager.HandleIssueCommentEvent(&IssueCommentEvent{
+		EventName:                "issue_comment",
+		Action:                   "created",
+		Repository:               "cloudbro-kube-ai/k13d",
+		IssueNumber:              107,
+		IssueTitle:               "Review it",
+		IssueURL:                 "https://github.com/cloudbro-kube-ai/k13d/issues/107",
+		CommentBody:              "k13d 코드리뷰 해줘",
+		CommentAuthor:            "alice",
+		CommentAuthorAssociation: "MEMBER",
+	})
+	if !result.Accepted {
+		t.Fatalf("HandleIssueCommentEvent() = %#v, want accepted", result)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		reporter.mu.Lock()
+		reviewCreated := reporter.reviewCreated
+		reviewBody := reporter.reviewBody
+		comments := append([]string(nil), reporter.issueComments...)
+		reporter.mu.Unlock()
+		if reviewCreated && len(comments) >= 2 {
+			if !strings.Contains(comments[0], "코드 리뷰 요청 접수") {
+				t.Fatalf("accepted comment = %q, want Korean review accepted", comments[0])
+			}
+			if !strings.Contains(comments[len(comments)-1], "코드 리뷰 완료") {
+				t.Fatalf("completion comment = %q, want Korean review success", comments[len(comments)-1])
+			}
+			if !strings.Contains(reviewBody, "## 자동 코드 리뷰") || !strings.Contains(reviewBody, "발견사항 없음") {
+				t.Fatalf("review body = %q, want Codex review body", reviewBody)
+			}
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("timed out waiting for review command")
+}
+
+func TestManagerQueueIssueEvent_RequiresOrgMember(t *testing.T) {
+	cfg := config.NewDefaultConfig().GitHub
+	cfg.Enabled = true
+	cfg.AllowedRepositories = []string{"cloudbro-kube-ai/k13d"}
+	cfg.TriggerLabel = "codex:auto"
+	cfg.RequireAuthorOrgMember = true
+
+	manager, err := NewManager(cfg)
+	if err != nil {
+		t.Fatalf("NewManager() error = %v", err)
+	}
+	defer manager.Close()
+	manager.reporter = &fakeReporter{orgMember: false}
+
+	result := manager.QueueIssueEvent(&IssueEvent{
+		EventName:      "issues",
+		Action:         "labeled",
+		Repository:     "cloudbro-kube-ai/k13d",
+		IssueNumber:    102,
+		IssueTitle:     "Automate me",
+		IssueURL:       "https://github.com/cloudbro-kube-ai/k13d/issues/102",
+		IssueAuthor:    "external-user",
+		Labels:         []string{"codex:auto"},
+		TriggeredLabel: "codex:auto",
+	})
+	if !result.Ignored {
+		t.Fatalf("QueueIssueEvent() = %#v, want ignored", result)
+	}
+	if !strings.Contains(result.Reason, "not a member") {
+		t.Fatalf("Reason = %q, want membership denial", result.Reason)
+	}
+}
+
+func TestManagerQueueIssueEvent_AllowsVerifiedOrgMember(t *testing.T) {
+	cfg := config.NewDefaultConfig().GitHub
+	cfg.Enabled = true
+	cfg.AllowedRepositories = []string{"cloudbro-kube-ai/k13d"}
+	cfg.TriggerLabel = "codex:auto"
+	cfg.RequireAuthorOrgMember = true
+
+	manager, err := NewManager(cfg)
+	if err != nil {
+		t.Fatalf("NewManager() error = %v", err)
+	}
+	defer manager.Close()
+	manager.reporter = &fakeReporter{orgMember: true}
+	manager.executor = &fakeExecutor{result: &ExecutionResult{}}
+
+	result := manager.QueueIssueEvent(&IssueEvent{
+		EventName:      "issues",
+		Action:         "labeled",
+		Repository:     "cloudbro-kube-ai/k13d",
+		IssueNumber:    103,
+		IssueTitle:     "Automate me",
+		IssueURL:       "https://github.com/cloudbro-kube-ai/k13d/issues/103",
+		IssueAuthor:    "org-user",
+		Labels:         []string{"codex:auto"},
+		TriggeredLabel: "codex:auto",
+	})
+	if !result.Accepted {
+		t.Fatalf("QueueIssueEvent() = %#v, want accepted", result)
+	}
 }
 
 func TestParsePreviewDeploymentOutput(t *testing.T) {

--- a/pkg/automation/secrets.go
+++ b/pkg/automation/secrets.go
@@ -1,0 +1,73 @@
+package automation
+
+import (
+	"os"
+	"regexp"
+	"strings"
+
+	"github.com/cloudbro-kube-ai/k13d/pkg/config"
+)
+
+const redactedSecret = "[REDACTED]"
+
+var githubTokenPattern = regexp.MustCompile(`\b(?:github_pat_[A-Za-z0-9_]{20,}|gh[pousr]_[A-Za-z0-9_]{20,})\b`)
+
+func commandEnvironment(placeholders map[string]string) []string {
+	return append(filterAutomationEnvironment(osEnvironment()), buildCommandEnv(placeholders)...)
+}
+
+var osEnvironment = os.Environ
+
+func filterAutomationEnvironment(env []string) []string {
+	out := make([]string, 0, len(env))
+	for _, entry := range env {
+		name, _, ok := strings.Cut(entry, "=")
+		if !ok || isGitHubSecretEnvName(name) {
+			continue
+		}
+		out = append(out, entry)
+	}
+	return out
+}
+
+func isGitHubSecretEnvName(name string) bool {
+	name = strings.ToUpper(strings.TrimSpace(name))
+	switch name {
+	case "GITHUB_TOKEN", "GH_TOKEN", "GITHUB_PAT", "K13D_GITHUB_TOKEN", "K13D_GITHUB_AUTOMATION_TOKEN":
+		return true
+	}
+	return strings.Contains(name, "GITHUB") && (strings.Contains(name, "TOKEN") || strings.Contains(name, "PAT"))
+}
+
+func RedactGitHubSecrets(text string, cfg config.GitHubAutomationConfig) string {
+	return redactSensitiveText(text, sensitiveGitHubValues(cfg))
+}
+
+func sensitiveGitHubValues(cfg config.GitHubAutomationConfig) []string {
+	values := []string{
+		cfg.PersonalAccessToken,
+		cfg.WebhookSecret,
+	}
+	for _, entry := range osEnvironment() {
+		name, value, ok := strings.Cut(entry, "=")
+		if ok && isGitHubSecretEnvName(name) {
+			values = append(values, value)
+		}
+	}
+	return values
+}
+
+func redactSensitiveText(text string, values []string) string {
+	if text == "" {
+		return ""
+	}
+	redacted := text
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if len(value) < 4 {
+			continue
+		}
+		redacted = strings.ReplaceAll(redacted, value, redactedSecret)
+	}
+	return githubTokenPattern.ReplaceAllString(redacted, redactedSecret)
+}

--- a/pkg/automation/types.go
+++ b/pkg/automation/types.go
@@ -51,17 +51,35 @@ type Job struct {
 }
 
 type IssueEvent struct {
-	EventName      string
-	Action         string
-	Repository     string
-	DefaultBranch  string
-	IssueNumber    int
-	IssueTitle     string
-	IssueBody      string
-	IssueURL       string
-	IssueAuthor    string
-	Labels         []string
-	TriggeredLabel string
+	EventName              string
+	Action                 string
+	Repository             string
+	DefaultBranch          string
+	IssueNumber            int
+	IssueTitle             string
+	IssueBody              string
+	IssueURL               string
+	IssueAuthor            string
+	IssueAuthorAssociation string
+	Labels                 []string
+	TriggeredLabel         string
+}
+
+type IssueCommentEvent struct {
+	EventName                string
+	Action                   string
+	Repository               string
+	DefaultBranch            string
+	IssueNumber              int
+	IssueTitle               string
+	IssueBody                string
+	IssueURL                 string
+	IssueAuthor              string
+	IssueAuthorAssociation   string
+	CommentBody              string
+	CommentAuthor            string
+	CommentAuthorAssociation string
+	Labels                   []string
 }
 
 type QueueResult struct {
@@ -98,4 +116,10 @@ type PreviewDeployment struct {
 type PullRequestInfo struct {
 	Number int
 	URL    string
+}
+
+type PullRequestMergeInfo struct {
+	SHA     string
+	Merged  bool
+	Message string
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"runtime"
+	"strconv"
 	"strings"
 
 	"github.com/adrg/xdg"
@@ -68,31 +69,37 @@ type NotificationsConfig struct {
 // GitHubAutomationConfig controls webhook-triggered issue automation that runs
 // local coding and review commands, then reports results back to GitHub.
 type GitHubAutomationConfig struct {
-	Enabled               bool     `yaml:"enabled" json:"enabled"`
-	WebhookSecret         string   `yaml:"webhook_secret" json:"-"`
-	PersonalAccessToken   string   `yaml:"personal_access_token" json:"-"`
-	AllowedRepositories   []string `yaml:"allowed_repositories" json:"allowed_repositories"`
-	TriggerLabel          string   `yaml:"trigger_label" json:"trigger_label"`
-	BaseBranch            string   `yaml:"base_branch" json:"base_branch"`
-	Remote                string   `yaml:"remote" json:"remote"`
-	RepoPath              string   `yaml:"repo_path" json:"repo_path"`
-	WorktreeRoot          string   `yaml:"worktree_root" json:"worktree_root"`
-	BranchPrefix          string   `yaml:"branch_prefix" json:"branch_prefix"`
-	DevelopmentCommand    []string `yaml:"development_command" json:"development_command"`
-	ReviewCommand         []string `yaml:"review_command" json:"review_command"`
-	DeployPreviewCommand  []string `yaml:"deploy_preview_command" json:"deploy_preview_command"`
-	AutoCommit            bool     `yaml:"auto_commit" json:"auto_commit"`
-	AutoPush              bool     `yaml:"auto_push" json:"auto_push"`
-	AutoCreatePR          bool     `yaml:"auto_create_pr" json:"auto_create_pr"`
-	WaitForCI             bool     `yaml:"wait_for_ci" json:"wait_for_ci"`
-	CIWaitTimeoutSeconds  int      `yaml:"ci_wait_timeout_seconds" json:"ci_wait_timeout_seconds"`
-	CIPollIntervalSeconds int      `yaml:"ci_poll_interval_seconds" json:"ci_poll_interval_seconds"`
-	AutoDeployPreview     bool     `yaml:"auto_deploy_preview" json:"auto_deploy_preview"`
-	PreviewURLBase        string   `yaml:"preview_url_base" json:"preview_url_base"`
-	PreviewPathPrefix     string   `yaml:"preview_path_prefix" json:"preview_path_prefix"`
-	PullRequestDraft      bool     `yaml:"pull_request_draft" json:"pull_request_draft"`
-	CleanupWorktrees      bool     `yaml:"cleanup_worktrees" json:"cleanup_worktrees"`
-	MaxConcurrentJobs     int      `yaml:"max_concurrent_jobs" json:"max_concurrent_jobs"`
+	Enabled                bool     `yaml:"enabled" json:"enabled"`
+	WebhookSecret          string   `yaml:"webhook_secret" json:"-"`
+	PersonalAccessToken    string   `yaml:"personal_access_token" json:"-"`
+	AllowedRepositories    []string `yaml:"allowed_repositories" json:"allowed_repositories"`
+	RequireAuthorOrgMember bool     `yaml:"require_author_org_member" json:"require_author_org_member"`
+	MentionOrgMembers      bool     `yaml:"mention_org_members" json:"mention_org_members"`
+	MentionMaxMembers      int      `yaml:"mention_max_members" json:"mention_max_members"`
+	ReviewLanguage         string   `yaml:"review_language" json:"review_language"`
+	TriggerLabel           string   `yaml:"trigger_label" json:"trigger_label"`
+	BaseBranch             string   `yaml:"base_branch" json:"base_branch"`
+	Remote                 string   `yaml:"remote" json:"remote"`
+	RepoPath               string   `yaml:"repo_path" json:"repo_path"`
+	WorktreeRoot           string   `yaml:"worktree_root" json:"worktree_root"`
+	BranchPrefix           string   `yaml:"branch_prefix" json:"branch_prefix"`
+	DevelopmentCommand     []string `yaml:"development_command" json:"development_command"`
+	ReviewCommand          []string `yaml:"review_command" json:"review_command"`
+	DeployPreviewCommand   []string `yaml:"deploy_preview_command" json:"deploy_preview_command"`
+	AutoCommit             bool     `yaml:"auto_commit" json:"auto_commit"`
+	AutoPush               bool     `yaml:"auto_push" json:"auto_push"`
+	AutoCreatePR           bool     `yaml:"auto_create_pr" json:"auto_create_pr"`
+	AllowIssueMerge        bool     `yaml:"allow_issue_merge" json:"allow_issue_merge"`
+	MergeMethod            string   `yaml:"merge_method" json:"merge_method"`
+	WaitForCI              bool     `yaml:"wait_for_ci" json:"wait_for_ci"`
+	CIWaitTimeoutSeconds   int      `yaml:"ci_wait_timeout_seconds" json:"ci_wait_timeout_seconds"`
+	CIPollIntervalSeconds  int      `yaml:"ci_poll_interval_seconds" json:"ci_poll_interval_seconds"`
+	AutoDeployPreview      bool     `yaml:"auto_deploy_preview" json:"auto_deploy_preview"`
+	PreviewURLBase         string   `yaml:"preview_url_base" json:"preview_url_base"`
+	PreviewPathPrefix      string   `yaml:"preview_path_prefix" json:"preview_path_prefix"`
+	PullRequestDraft       bool     `yaml:"pull_request_draft" json:"pull_request_draft"`
+	CleanupWorktrees       bool     `yaml:"cleanup_worktrees" json:"cleanup_worktrees"`
+	MaxConcurrentJobs      int      `yaml:"max_concurrent_jobs" json:"max_concurrent_jobs"`
 }
 
 // SMTPConfig holds email notification settings
@@ -371,6 +378,12 @@ func GetRuntimeSourceInfo() RuntimeSourceInfo {
 	for _, key := range []string{
 		"K13D_JWT_SECRET",
 		"K13D_DEFAULT_ROLE",
+		"K13D_GITHUB_AUTOMATION_REQUIRE_ORG_MEMBER",
+		"K13D_GITHUB_AUTOMATION_MENTION_ORG_MEMBERS",
+		"K13D_GITHUB_AUTOMATION_MENTION_MAX_MEMBERS",
+		"K13D_GITHUB_AUTOMATION_REVIEW_LANGUAGE",
+		"K13D_GITHUB_AUTOMATION_ALLOW_ISSUE_MERGE",
+		"K13D_GITHUB_AUTOMATION_MERGE_METHOD",
 	} {
 		if strings.TrimSpace(os.Getenv(key)) != "" {
 			info.EnvOverrides = append(info.EnvOverrides, key)
@@ -508,23 +521,29 @@ func NewDefaultConfig() *Config {
 			Servers: []MCPServer{},
 		},
 		GitHub: GitHubAutomationConfig{
-			Enabled:               false,
-			TriggerLabel:          "codex:auto",
-			BaseBranch:            "main",
-			Remote:                "origin",
-			WorktreeRoot:          DefaultGitHubAutomationWorktreeRoot(),
-			BranchPrefix:          "codex/issue-",
-			AutoCommit:            true,
-			AutoPush:              true,
-			AutoCreatePR:          true,
-			WaitForCI:             true,
-			CIWaitTimeoutSeconds:  600,
-			CIPollIntervalSeconds: 10,
-			AutoDeployPreview:     false,
-			PreviewPathPrefix:     "/previews",
-			PullRequestDraft:      true,
-			CleanupWorktrees:      false,
-			MaxConcurrentJobs:     1,
+			Enabled:                false,
+			TriggerLabel:           "codex:auto",
+			BaseBranch:             "main",
+			Remote:                 "origin",
+			WorktreeRoot:           DefaultGitHubAutomationWorktreeRoot(),
+			BranchPrefix:           "codex/issue-",
+			RequireAuthorOrgMember: true,
+			MentionOrgMembers:      true,
+			MentionMaxMembers:      20,
+			ReviewLanguage:         "ko",
+			AutoCommit:             true,
+			AutoPush:               true,
+			AutoCreatePR:           true,
+			AllowIssueMerge:        false,
+			MergeMethod:            "squash",
+			WaitForCI:              true,
+			CIWaitTimeoutSeconds:   600,
+			CIPollIntervalSeconds:  10,
+			AutoDeployPreview:      false,
+			PreviewPathPrefix:      "/previews",
+			PullRequestDraft:       true,
+			CleanupWorktrees:       false,
+			MaxConcurrentJobs:      1,
 		},
 		Prometheus: PrometheusConfig{
 			ExposeMetrics:      false,
@@ -829,6 +848,26 @@ func applyEnvOverrides(cfg *Config) {
 	}
 	if v := os.Getenv("K13D_GITHUB_AUTOMATION_TRIGGER_LABEL"); v != "" {
 		cfg.GitHub.TriggerLabel = v
+	}
+	if v := os.Getenv("K13D_GITHUB_AUTOMATION_REQUIRE_ORG_MEMBER"); v != "" {
+		cfg.GitHub.RequireAuthorOrgMember = strings.EqualFold(v, "true") || v == "1" || strings.EqualFold(v, "yes")
+	}
+	if v := os.Getenv("K13D_GITHUB_AUTOMATION_MENTION_ORG_MEMBERS"); v != "" {
+		cfg.GitHub.MentionOrgMembers = strings.EqualFold(v, "true") || v == "1" || strings.EqualFold(v, "yes")
+	}
+	if v := os.Getenv("K13D_GITHUB_AUTOMATION_MENTION_MAX_MEMBERS"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			cfg.GitHub.MentionMaxMembers = n
+		}
+	}
+	if v := os.Getenv("K13D_GITHUB_AUTOMATION_REVIEW_LANGUAGE"); v != "" {
+		cfg.GitHub.ReviewLanguage = v
+	}
+	if v := os.Getenv("K13D_GITHUB_AUTOMATION_ALLOW_ISSUE_MERGE"); v != "" {
+		cfg.GitHub.AllowIssueMerge = strings.EqualFold(v, "true") || v == "1" || strings.EqualFold(v, "yes")
+	}
+	if v := os.Getenv("K13D_GITHUB_AUTOMATION_MERGE_METHOD"); v != "" {
+		cfg.GitHub.MergeMethod = v
 	}
 	if v := os.Getenv("K13D_GITHUB_AUTOMATION_WAIT_FOR_CI"); v != "" {
 		cfg.GitHub.WaitForCI = strings.EqualFold(v, "true") || v == "1" || strings.EqualFold(v, "yes")

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -130,6 +130,12 @@ func TestNewDefaultConfig(t *testing.T) {
 	if !cfg.GitHub.AutoCreatePR {
 		t.Error("GitHub.AutoCreatePR should be true by default")
 	}
+	if cfg.GitHub.AllowIssueMerge {
+		t.Error("GitHub.AllowIssueMerge should be false by default")
+	}
+	if cfg.GitHub.MergeMethod != "squash" {
+		t.Errorf("GitHub.MergeMethod = %s, want squash", cfg.GitHub.MergeMethod)
+	}
 	if !cfg.GitHub.WaitForCI {
 		t.Error("GitHub.WaitForCI should be true by default")
 	}
@@ -138,6 +144,18 @@ func TestNewDefaultConfig(t *testing.T) {
 	}
 	if cfg.GitHub.CIPollIntervalSeconds != 10 {
 		t.Errorf("GitHub.CIPollIntervalSeconds = %d, want 10", cfg.GitHub.CIPollIntervalSeconds)
+	}
+	if !cfg.GitHub.RequireAuthorOrgMember {
+		t.Error("GitHub.RequireAuthorOrgMember should be true by default")
+	}
+	if !cfg.GitHub.MentionOrgMembers {
+		t.Error("GitHub.MentionOrgMembers should be true by default")
+	}
+	if cfg.GitHub.MentionMaxMembers != 20 {
+		t.Errorf("GitHub.MentionMaxMembers = %d, want 20", cfg.GitHub.MentionMaxMembers)
+	}
+	if cfg.GitHub.ReviewLanguage != "ko" {
+		t.Errorf("GitHub.ReviewLanguage = %s, want ko", cfg.GitHub.ReviewLanguage)
 	}
 	if cfg.GitHub.PreviewPathPrefix != "/previews" {
 		t.Errorf("GitHub.PreviewPathPrefix = %s, want /previews", cfg.GitHub.PreviewPathPrefix)
@@ -694,6 +712,12 @@ func TestApplyEnvOverrides_GitHubAutomation(t *testing.T) {
 	t.Setenv("K13D_GITHUB_AUTOMATION_TOKEN", "token")
 	t.Setenv("K13D_GITHUB_AUTOMATION_REPO_PATH", "/tmp/repo")
 	t.Setenv("K13D_GITHUB_AUTOMATION_TRIGGER_LABEL", "run:auto")
+	t.Setenv("K13D_GITHUB_AUTOMATION_REQUIRE_ORG_MEMBER", "false")
+	t.Setenv("K13D_GITHUB_AUTOMATION_MENTION_ORG_MEMBERS", "false")
+	t.Setenv("K13D_GITHUB_AUTOMATION_MENTION_MAX_MEMBERS", "7")
+	t.Setenv("K13D_GITHUB_AUTOMATION_REVIEW_LANGUAGE", "en")
+	t.Setenv("K13D_GITHUB_AUTOMATION_ALLOW_ISSUE_MERGE", "true")
+	t.Setenv("K13D_GITHUB_AUTOMATION_MERGE_METHOD", "rebase")
 	t.Setenv("K13D_GITHUB_AUTOMATION_WAIT_FOR_CI", "false")
 	t.Setenv("K13D_GITHUB_AUTOMATION_AUTO_DEPLOY_PREVIEW", "true")
 	t.Setenv("K13D_GITHUB_AUTOMATION_PREVIEW_URL_BASE", "https://fingerscore.net")
@@ -715,6 +739,24 @@ func TestApplyEnvOverrides_GitHubAutomation(t *testing.T) {
 	}
 	if cfg.GitHub.TriggerLabel != "run:auto" {
 		t.Fatalf("TriggerLabel = %s", cfg.GitHub.TriggerLabel)
+	}
+	if cfg.GitHub.RequireAuthorOrgMember {
+		t.Fatal("RequireAuthorOrgMember should be overridden to false")
+	}
+	if cfg.GitHub.MentionOrgMembers {
+		t.Fatal("MentionOrgMembers should be overridden to false")
+	}
+	if cfg.GitHub.MentionMaxMembers != 7 {
+		t.Fatalf("MentionMaxMembers = %d", cfg.GitHub.MentionMaxMembers)
+	}
+	if cfg.GitHub.ReviewLanguage != "en" {
+		t.Fatalf("ReviewLanguage = %s", cfg.GitHub.ReviewLanguage)
+	}
+	if !cfg.GitHub.AllowIssueMerge {
+		t.Fatal("AllowIssueMerge should be overridden to true")
+	}
+	if cfg.GitHub.MergeMethod != "rebase" {
+		t.Fatalf("MergeMethod = %s", cfg.GitHub.MergeMethod)
 	}
 	if cfg.GitHub.WaitForCI {
 		t.Fatal("WaitForCI should be overridden to false")

--- a/pkg/web/github_automation.go
+++ b/pkg/web/github_automation.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/cloudbro-kube-ai/k13d/pkg/automation"
+	"github.com/cloudbro-kube-ai/k13d/pkg/config"
 )
 
 func (s *Server) handleGitHubAutomationWebhook(w http.ResponseWriter, r *http.Request) {
@@ -29,13 +30,27 @@ func (s *Server) handleGitHubAutomationWebhook(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	event, err := automation.ParseIssueEvent(r.Header.Get("X-GitHub-Event"), payload)
-	if err != nil {
-		WriteError(w, NewAPIError(ErrCodeBadRequest, err.Error()))
+	eventName := r.Header.Get("X-GitHub-Event")
+	var result automation.QueueResult
+	switch eventName {
+	case "issues":
+		event, err := automation.ParseIssueEvent(eventName, payload)
+		if err != nil {
+			WriteError(w, NewAPIError(ErrCodeBadRequest, err.Error()))
+			return
+		}
+		result = s.automation.QueueIssueEvent(event)
+	case "issue_comment":
+		event, err := automation.ParseIssueCommentEvent(eventName, payload)
+		if err != nil {
+			WriteError(w, NewAPIError(ErrCodeBadRequest, err.Error()))
+			return
+		}
+		result = s.automation.HandleIssueCommentEvent(event)
+	default:
+		WriteError(w, NewAPIError(ErrCodeBadRequest, "unsupported github event: "+eventName))
 		return
 	}
-
-	result := s.automation.QueueIssueEvent(event)
 	w.Header().Set("Content-Type", "application/json")
 	status := http.StatusAccepted
 	if result.Ignored {
@@ -58,7 +73,7 @@ func (s *Server) handleGitHubAutomationStatus(w http.ResponseWriter, r *http.Req
 
 	resp := map[string]interface{}{
 		"enabled": false,
-		"config":  s.cfg.GitHub,
+		"config":  safeGitHubAutomationConfig(s.cfg.GitHub),
 		"jobs":    jobs,
 	}
 	if s.automation != nil {
@@ -94,4 +109,48 @@ func (s *Server) handleGitHubAutomationJob(w http.ResponseWriter, r *http.Reques
 
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(job)
+}
+
+func safeGitHubAutomationConfig(cfg config.GitHubAutomationConfig) map[string]interface{} {
+	redactArgs := func(args []string) []string {
+		out := make([]string, 0, len(args))
+		for _, arg := range args {
+			out = append(out, automation.RedactGitHubSecrets(arg, cfg))
+		}
+		return out
+	}
+
+	return map[string]interface{}{
+		"enabled":                          cfg.Enabled,
+		"webhook_secret_configured":        strings.TrimSpace(cfg.WebhookSecret) != "",
+		"personal_access_token_configured": strings.TrimSpace(cfg.PersonalAccessToken) != "",
+		"allowed_repositories":             cfg.AllowedRepositories,
+		"require_author_org_member":        cfg.RequireAuthorOrgMember,
+		"mention_org_members":              cfg.MentionOrgMembers,
+		"mention_max_members":              cfg.MentionMaxMembers,
+		"review_language":                  cfg.ReviewLanguage,
+		"trigger_label":                    cfg.TriggerLabel,
+		"base_branch":                      cfg.BaseBranch,
+		"remote":                           cfg.Remote,
+		"repo_path":                        cfg.RepoPath,
+		"worktree_root":                    cfg.WorktreeRoot,
+		"branch_prefix":                    cfg.BranchPrefix,
+		"development_command":              redactArgs(cfg.DevelopmentCommand),
+		"review_command":                   redactArgs(cfg.ReviewCommand),
+		"deploy_preview_command":           redactArgs(cfg.DeployPreviewCommand),
+		"auto_commit":                      cfg.AutoCommit,
+		"auto_push":                        cfg.AutoPush,
+		"auto_create_pr":                   cfg.AutoCreatePR,
+		"allow_issue_merge":                cfg.AllowIssueMerge,
+		"merge_method":                     cfg.MergeMethod,
+		"wait_for_ci":                      cfg.WaitForCI,
+		"ci_wait_timeout_seconds":          cfg.CIWaitTimeoutSeconds,
+		"ci_poll_interval_seconds":         cfg.CIPollIntervalSeconds,
+		"auto_deploy_preview":              cfg.AutoDeployPreview,
+		"preview_url_base":                 cfg.PreviewURLBase,
+		"preview_path_prefix":              cfg.PreviewPathPrefix,
+		"pull_request_draft":               cfg.PullRequestDraft,
+		"cleanup_worktrees":                cfg.CleanupWorktrees,
+		"max_concurrent_jobs":              cfg.MaxConcurrentJobs,
+	}
 }

--- a/pkg/web/github_automation_test.go
+++ b/pkg/web/github_automation_test.go
@@ -35,6 +35,7 @@ func TestHandleGitHubAutomationWebhookAccepted(t *testing.T) {
 			"title":"Automate me",
 			"body":"Please automate",
 			"html_url":"https://github.com/cloudbro-kube-ai/k13d/issues/1",
+			"author_association":"MEMBER",
 			"user":{"login":"alice"},
 			"labels":[{"name":"codex:auto"}]
 		}
@@ -98,6 +99,35 @@ func TestHandleGitHubAutomationJobNotFound(t *testing.T) {
 	s.handleGitHubAutomationJob(rec, req)
 	if rec.Code != http.StatusNotFound {
 		t.Fatalf("status = %d, want %d", rec.Code, http.StatusNotFound)
+	}
+}
+
+func TestHandleGitHubAutomationStatusRedactsSecrets(t *testing.T) {
+	cfg := config.NewDefaultConfig()
+	cfg.GitHub.Enabled = true
+	cfg.GitHub.WebhookSecret = "webhook-secret-value"
+	cfg.GitHub.PersonalAccessToken = "github_pat_abcdefghijklmnopqrstuvwxyz123456"
+	cfg.GitHub.DevelopmentCommand = []string{"sh", "-c", "echo github_pat_abcdefghijklmnopqrstuvwxyz123456"}
+
+	manager, err := automation.NewManager(cfg.GitHub)
+	if err != nil {
+		t.Fatalf("NewManager() error = %v", err)
+	}
+	defer manager.Close()
+
+	s := &Server{cfg: cfg, automation: manager}
+	req := httptest.NewRequest(http.MethodGet, "/api/admin/github-automation/status", nil)
+	rec := httptest.NewRecorder()
+	s.handleGitHubAutomationStatus(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	body := rec.Body.String()
+	if bytes.Contains([]byte(body), []byte(cfg.GitHub.WebhookSecret)) || bytes.Contains([]byte(body), []byte(cfg.GitHub.PersonalAccessToken)) {
+		t.Fatalf("status body leaked secret: %s", body)
+	}
+	if !bytes.Contains([]byte(body), []byte("personal_access_token_configured")) {
+		t.Fatalf("status body = %s, want configured flag", body)
 	}
 }
 

--- a/scripts/run-agent-review.sh
+++ b/scripts/run-agent-review.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CODEX_BIN="${K13D_CODEX_BIN:-codex}"
+BASE_BRANCH="${K13D_GHA_BASE_BRANCH:-main}"
+ISSUE_NUMBER="${K13D_GHA_ISSUE_NUMBER:-unknown}"
+ISSUE_TITLE="${K13D_GHA_ISSUE_TITLE:-}"
+ISSUE_URL="${K13D_GHA_ISSUE_URL:-}"
+REPOSITORY="${K13D_GHA_REPOSITORY:-}"
+REVIEW_LANGUAGE="${K13D_GHA_REVIEW_LANGUAGE:-ko}"
+MODEL="${K13D_CODEX_REVIEW_MODEL:-}"
+
+if ! command -v "$CODEX_BIN" >/dev/null 2>&1; then
+  echo "Codex CLI is required for automated code review. Set K13D_CODEX_BIN or install codex." >&2
+  exit 127
+fi
+
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  echo "run-agent-review.sh must run inside a git worktree." >&2
+  exit 1
+fi
+
+REMOTE="${K13D_GHA_REMOTE:-origin}"
+git fetch "$REMOTE" "$BASE_BRANCH" --quiet >/dev/null 2>&1 || true
+
+BASE_REF="$BASE_BRANCH"
+if git rev-parse --verify "$REMOTE/$BASE_BRANCH" >/dev/null 2>&1; then
+  BASE_REF="$REMOTE/$BASE_BRANCH"
+elif ! git rev-parse --verify "$BASE_REF" >/dev/null 2>&1; then
+  BASE_REF="HEAD~1"
+fi
+
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/k13d-codex-review.XXXXXX")"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+LAST_MESSAGE="$TMP_DIR/review.md"
+LOG_FILE="$TMP_DIR/codex.log"
+
+PROMPT="$(cat <<PROMPT
+Review the changes for k13d GitHub issue #${ISSUE_NUMBER}.
+
+Issue title: ${ISSUE_TITLE}
+Issue URL: ${ISSUE_URL}
+Repository: ${REPOSITORY}
+Preferred review language: ${REVIEW_LANGUAGE}
+
+Use a strict code-review mindset:
+- Put findings first, ordered by severity.
+- Focus on bugs, regressions, security risks, concurrency hazards, broken tests, and missing verification.
+- Include file and line references when possible.
+- If there are no findings, say that explicitly and mention residual risks or test gaps.
+- Do not print secrets, tokens, or raw environment values.
+- Write the final review in Korean when the preferred review language is Korean.
+PROMPT
+)"
+
+ARGS=(exec review --base "$BASE_REF" --ephemeral --output-last-message "$LAST_MESSAGE")
+if [[ -n "$(git status --porcelain)" ]]; then
+  ARGS+=(--uncommitted)
+fi
+if [[ -n "$MODEL" ]]; then
+  ARGS+=(-m "$MODEL")
+fi
+
+if ! printf '%s\n' "$PROMPT" | "$CODEX_BIN" "${ARGS[@]}" >"$LOG_FILE" 2>&1; then
+  cat "$LOG_FILE" >&2
+  exit 1
+fi
+
+if [[ -s "$LAST_MESSAGE" ]]; then
+  cat "$LAST_MESSAGE"
+else
+  cat "$LOG_FILE"
+fi


### PR DESCRIPTION
## Summary
- restrict GitHub issue automation to organization members and reuse one stable issue branch/PR
- add Korean issue/PR reporting, org mentions, assignees/reviewers, preview links, optional issue-comment merge, and issue-comment Codex review reruns
- post the CI/CD verification path on the generated PR after checks and preview deployment finish
- close the linked GitHub issue as completed after a successful issue-requested merge, with a warning comment if issue closing lacks permission
- protect GitHub tokens by stripping token-like env vars from agent commands and redacting captured output/status
- add `scripts/run-agent-review.sh` for `codex exec review`
- make GitHub Issues friendlier with Korean Issue Forms, including a guided `Codex 개발 요청` form that keeps `codex:auto` opt-in after human triage
- document the issue-only natural-language workflow, review/merge commands, token safety, preview routing, PR verification links, issue completion, and friendly issue flow

## Validation
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/ISSUE_TEMPLATE/*.yml`
- `bash -n scripts/run-agent-review.sh`
- `go test -count=1 ./pkg/automation`
- `go test -count=1 ./pkg/config ./pkg/web`
- `go test -count=1 ./pkg/automation ./pkg/config ./pkg/web`
- `go test ./...`
- `go build ./...`
- `go vet ./...`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest run --config .golangci.yml ./...`
- `git diff --check`
- `mkdocs build --strict`
- `make build`
- Codex review smoke: ran `scripts/run-agent-review.sh` in a tiny temporary git repo and confirmed it produced a review finding through `codex exec review`

## Notes
- The friendly issue form applies `triage`, not `codex:auto`, so automation still starts only after an org member explicitly labels the issue.
- Generated PRs now receive a `k13d CI/CD 확인 경로` comment with CI status/logs and preview URL when available.
- The local `golangci-lint` binary is not installed here, so lint was run through `go run .../golangci-lint/v2@latest` without changing repository dependencies.
- `.claude/` remains untracked and untouched.
