### PR TITLE
fix: correct docs CI version detection and tag v1.1.0

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -74,9 +74,9 @@ jobs:
       - name: Get k13d version
         id: version
         run: |
-          VERSION=$(grep -m1 'version:' docs-site/mkdocs.yml | awk '{print $2}' || echo "latest")
+          # Extract first version from CHANGELOG.md, fall back to git tag
+          VERSION=$(grep -m1 '^## \[[0-9]' CHANGELOG.md | sed 's/.*\[\([^]]*\)\].*/\1/' || echo "")
           if [ -z "$VERSION" ]; then
-            # Try to get version from git tag
             VERSION=$(git describe --tags --abbrev=0 2>/dev/null || echo "latest")
           fi
           echo "version=$VERSION" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Problem

The docs CI workflow (`docs.yml`) was detecting the wrong version for `mike deploy`. It tried to grep `version:` from `mkdocs.yml`, but that matches the mike config key (`version:\n  provider: mike`) instead of the actual release version. The fallback to `git describe --tags` gave `v1.0.1` instead of `v1.1.0`.

## Fix

1. **Version detection**: Changed to read the first version from `CHANGELOG.md` (e.g. `1.1.0`) instead of grepping `mkdocs.yml`. Falls back to `git describe --tags` if parsing fails.
2. **Tag**: Created and pushed `v1.1.0` git tag from main, which will make `mike deploy` use the correct version label on the next CI run.

## Next

After merging, the next push to main with docs changes will deploy as `v1.1.0` in the versioned docs site.