### PR TITLE
fix: restore CHANGELOG.md keep-a-changelog format for correct doc version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,49 @@ All notable changes to k13d will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+## [1.1.0] - 2026-07-24
+
+### Added
+- **Screen Ghosting Fix**: Eliminated TUI visual artifacts during modal transitions and AI streaming
+  - Added 50ms draw throttle for AI streaming callbacks to prevent goroutine contention
+  - Added periodic 500ms safety sync in `SetBeforeDrawFunc` as repaint safety net
+  - Created `showModal()`/`closeModal()` helpers that trigger `screen.Sync()` on every modal transition
+
+- **AI Chat History Preservation**: Previous Q&A sessions are now preserved when asking new questions
+  - Chat history separated by visual dividers (`────────────────────────────`)
+  - Scroll up to review previous conversations within the same session
+
+- **Autocomplete Dropdown**: k9s-style command autocomplete with dropdown overlay
+  - Shows dropdown when 2+ completions match typed text
+  - Navigate with Up/Down arrows, select with Tab/Enter, dismiss with Esc
+  - Single-match dimmed hint text preserved for quick completion
+
+- **Configurable Resource Aliases** (`aliases.yaml`): Custom command shortcuts
+  - Define short aliases for resource commands (e.g., `pp` → `pods`)
+  - `:alias` command to view all configured aliases
+  - Aliases merged with built-in commands in autocomplete
+
+- **Per-Resource Sort Defaults** (`views.yaml`): Remember sort preferences per resource
+  - Configure default sort column and direction per resource type
+  - Applied automatically when navigating to a resource
+
+- **LLM Model Switching** (`:model` command): Switch AI models from TUI
+  - `:model` shows modal with all configured model profiles
+  - `:model <name>` switches directly to a named profile
+  - Active model marked with `*` in selector
+
+- **Plugin System TUI Integration**: External plugins now accessible from TUI
+  - Plugins loaded from `plugins.yaml` on startup
+  - Plugin keyboard shortcuts active on matching resource scopes
+  - `:plugins` command shows all available plugins
+  - Supports foreground (with TUI suspend) and background execution
+
+### Changed
+- All 37+ `AddPage()`/`RemovePage()` calls migrated to `showModal()`/`closeModal()` helpers
+- Command handling refactored to support prefix matching (`:model <name>`)
+
 ## [1.0.1] - 2026-04-13
 
 ### Security
@@ -279,49 +322,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Sidebar reorganized: Visualization (Topology, Applications), Operations (Validate, Healing, Helm), Monitoring (Metrics, Audit Logs, Reports)
 - XRay renamed to "Topology Tree" for consistency with existing Topology graph view
 - Pulse renamed to "Metrics" for consistency with existing metrics charts
-
-## [Unreleased]
-
-## [1.1.0] - 2026-07-24
-
-### Added
-- **Screen Ghosting Fix**: Eliminated TUI visual artifacts during modal transitions and AI streaming
-  - Added 50ms draw throttle for AI streaming callbacks to prevent goroutine contention
-  - Added periodic 500ms safety sync in `SetBeforeDrawFunc` as repaint safety net
-  - Created `showModal()`/`closeModal()` helpers that trigger `screen.Sync()` on every modal transition
-
-- **AI Chat History Preservation**: Previous Q&A sessions are now preserved when asking new questions
-  - Chat history separated by visual dividers (`────────────────────────────`)
-  - Scroll up to review previous conversations within the same session
-
-- **Autocomplete Dropdown**: k9s-style command autocomplete with dropdown overlay
-  - Shows dropdown when 2+ completions match typed text
-  - Navigate with Up/Down arrows, select with Tab/Enter, dismiss with Esc
-  - Single-match dimmed hint text preserved for quick completion
-
-- **Configurable Resource Aliases** (`aliases.yaml`): Custom command shortcuts
-  - Define short aliases for resource commands (e.g., `pp` → `pods`)
-  - `:alias` command to view all configured aliases
-  - Aliases merged with built-in commands in autocomplete
-
-- **Per-Resource Sort Defaults** (`views.yaml`): Remember sort preferences per resource
-  - Configure default sort column and direction per resource type
-  - Applied automatically when navigating to a resource
-
-- **LLM Model Switching** (`:model` command): Switch AI models from TUI
-  - `:model` shows modal with all configured model profiles
-  - `:model <name>` switches directly to a named profile
-  - Active model marked with `*` in selector
-
-- **Plugin System TUI Integration**: External plugins now accessible from TUI
-  - Plugins loaded from `plugins.yaml` on startup
-  - Plugin keyboard shortcuts active on matching resource scopes
-  - `:plugins` command shows all available plugins
-  - Supports foreground (with TUI suspend) and background execution
-
-### Changed
-- All 37+ `AddPage()`/`RemovePage()` calls migrated to `showModal()`/`closeModal()` helpers
-- Command handling refactored to support prefix matching (`:model <name>`)
 
 ## [0.6.3] - 2026-02-08
 


### PR DESCRIPTION
## Problem

When running the docs CI workflow, the version detection (## [1.1.0] - 2026-07-24) extracted `1.0.1` instead of `1.1.0`, because:

- The `## [Unreleased]` and `## [1.1.0]` sections were appended at the **end** of the file (after `0.6.3`)
- The first numerical `## [0-9]` entry was `## [1.0.1]` at line 8
- This caused the docs site to deploy as version `1.0.1` instead of `1.1.0`

## Fix

- Moved `## [Unreleased]` and `## [1.1.0] - 2026-07-24` sections to the **top** of CHANGELOG.md, following keep-a-changelog format
- Version detection now correctly finds `1.1.0` as the first numerical version

## Verification

```
$ grep -m1 '^## \[[0-9]' CHANGELOG.md | sed 's/.*\[\([^]]*\)\].*/\1/'
1.1.0
```

## Next Steps

After merging, re-run the docs workflow to deploy v1.1.0.