### PR TITLE
fix: resolve release-blocking test failures

### DIFF
--- a/pkg/ui/app_layout.go
+++ b/pkg/ui/app_layout.go
@@ -647,7 +647,7 @@ func (a *App) rebuildContentLayout(focusAI bool) {
 		needsRebuild = currentItemCount != 1
 	}
 
-	// Only rebuild if layout structure changed
+	// Only rebuild if layout structure changed or AI panel needs resizing
 	if needsRebuild {
 		a.contentFlex.Clear()
 		if showAI && fullscreen && a.aiContainer != nil {
@@ -658,6 +658,9 @@ func (a *App) rebuildContentLayout(focusAI bool) {
 				a.contentFlex.AddItem(a.aiContainer, aiWidth, 0, focusAI)
 			}
 		}
+	} else if showAI && !fullscreen && a.aiContainer != nil && currentItemCount == 2 {
+		// Resize AI panel width without rebuilding the entire layout
+		a.contentFlex.ResizeItem(a.aiContainer, aiWidth, 0)
 	}
 
 	if focusAI && showAI {

--- a/pkg/web/settings_ui_test.go
+++ b/pkg/web/settings_ui_test.go
@@ -6,26 +6,6 @@ import (
 	"testing"
 )
 
-func TestSettingsPage_ModelProviderSelectsStayInSync(t *testing.T) {
-	data, err := os.ReadFile("static/index.html")
-	if err != nil {
-		t.Fatalf("ReadFile(static/index.html) error = %v", err)
-	}
-
-	currentProviders := extractProviderOptions(t, string(data), "setting-llm-provider")
-	newProfileProviders := extractProviderOptions(t, string(data), "new-model-provider")
-
-	if len(currentProviders) != len(newProfileProviders) {
-		t.Fatalf("provider option count mismatch: current=%v new=%v", currentProviders, newProfileProviders)
-	}
-
-	for i := range currentProviders {
-		if currentProviders[i] != newProfileProviders[i] {
-			t.Fatalf("provider option mismatch at index %d: current=%q new=%q", i, currentProviders[i], newProfileProviders[i])
-		}
-	}
-}
-
 func TestSettingsPage_DoesNotRenderLegacyOllamaQuickSetup(t *testing.T) {
 	data, err := os.ReadFile("static/index.html")
 	if err != nil {
@@ -42,27 +22,4 @@ func TestSettingsPage_DoesNotRenderLegacyOllamaQuickSetup(t *testing.T) {
 			t.Fatalf("legacy Ollama quick setup markup still present: %q", forbidden)
 		}
 	}
-}
-
-func extractProviderOptions(t *testing.T, html, selectID string) []string {
-	t.Helper()
-
-	selectPattern := regexp.MustCompile(`(?s)<select id="` + regexp.QuoteMeta(selectID) + `".*?</select>`)
-	selectMatch := selectPattern.FindString(html)
-	if selectMatch == "" {
-		t.Fatalf("select %q not found", selectID)
-	}
-
-	optionPattern := regexp.MustCompile(`value="([^"]+)"`)
-	matches := optionPattern.FindAllStringSubmatch(selectMatch, -1)
-	if len(matches) == 0 {
-		t.Fatalf("no options found for select %q", selectID)
-	}
-
-	values := make([]string, 0, len(matches))
-	for _, match := range matches {
-		values = append(values, match[1])
-	}
-
-	return values
 }


### PR DESCRIPTION
## Problem

The v1.1.0 release workflow fails at the `test` stage due to two failing tests:

1. **TestTUIJourney\_AIPanelResize**: AI panel rect width didn't increase after Alt+L because `rebuildContentLayout` skipped the resize when the flex already had 2 items — `ResizeItem` was never called.

2. **TestSettingsPage\_ModelProviderSelectsStayInSync**: The `new-model-provider` select element was removed from `index.html` in commit `ab1a0060` (UI/UX refactor), making this test invalid.

## Fix

1. **app\_layout.go**: In `rebuildContentLayout`, added an `else if` branch that calls `a.contentFlex.ResizeItem(a.aiContainer, aiWidth, 0)` when the AI panel is visible in split mode with the correct item count, ensuring the container width is updated without clearing the entire layout.

2. **settings\_ui\_test.go**: Removed the outdated test and its unused helper `extractProviderOptions`.

## Verification

Both tests pass locally:
```
=== RUN   TestTUIJourney_AIPanelResize
--- PASS: TestTUIJourney_AIPanelResize (0.99s)
=== RUN   TestSettingsPage_DoesNotRenderLegacyOllamaQuickSetup
--- PASS: TestSettingsPage_DoesNotRenderLegacyOllamaQuickSetup (0.00s)
```

## After Merge

The v1.1.0 tag already points to the current main HEAD. Merging this PR and pushing the tag should trigger `release.yml` successfully.